### PR TITLE
New x86 semantics

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -45,7 +45,7 @@ data AstNodeType = BvaddNode AstNodeType AstNodeType
              | BvuremNode AstNodeType AstNodeType
              | BvxnorNode AstNodeType AstNodeType
              | BvxorNode AstNodeType AstNodeType
-             | BvNode Word64 Int
+             | BvNode Word64 Word8
              | CompoundNode -- ! `[<expr1> <expr2> <expr3> ...]` node
              | ConcatNode [AstNodeType]
              | DecimalNode Int --float?

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -52,7 +52,7 @@ data AstNodeType = BvaddNode AstNodeType AstNodeType
              | DeclareNode --wtf?
              | DistinctNode AstNodeType AstNodeType
              | EqualNode AstNodeType AstNodeType
-             | ExtractNode Int Int  AstNodeType -- ! `((_ extract <high> <low>) <expr>)` node
+             | ExtractNode Word8 Word8  AstNodeType -- ! `((_ extract <high> <low>) <expr>)` node
              | IffNode AstNodeType AstNodeType -- ! `(iff <expr1> <expr2>)`
              | IteNode AstNodeType AstNodeType AstNodeType -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
              | LandNode AstNodeType AstNodeType

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -7,10 +7,11 @@ import           Hapstone.Internal.Capstone as Capstone
 import           Hapstone.Internal.X86      as X86
 import           Data.Word
 
-getOperandAst :: CsX86OpValue -> AstNodeType
-getOperandAst (Imm value) = BvNode value 32
-getOperandAst (Reg reg) = (GetReg (X86Reg reg))
-getOperandAst (Mem mem) = Read (getLeaAst mem)
+getOperandAst :: CsX86Op -> AstNodeType
+getOperandAst op = case value op of
+  (Imm value) -> BvNode value ((size op) * 8)
+  (Reg reg) -> GetReg (X86Reg reg)
+  (Mem mem) -> Read (getLeaAst mem)
 
 
 getLeaAst :: X86OpMemStruct -> AstNodeType

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ main :: IO ()
 main = do
   -- contents <- BS.readFile "bs/blackcipher.aes"
   print "this should be in test/"
-  let input = [0xB8, 0x01, 0x00, 0x00, 0x00, 0xB8, 0x02, 0x00, 0x00, 0x00]
+  let input = [0x04, 0x0A]
   asm <- disasm_buf input
   case asm of
     Left _ -> print "error"

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -12,11 +12,14 @@ import           Data.Maybe
 
 --ll, ml, hl
 
+--cf_add_s inst parent dst op1 op2 =
+
+
 add_s :: CsInsn -> [AstNodeType]
 add_s inst =
   let (op1 : op2 : _ ) = x86operands inst
-      op1ast = getOperandAst $ value op1
-      op2ast = getOperandAst $ value op2
+      op1ast = getOperandAst op1
+      op2ast = getOperandAst op2
   in [
       store_node (value op1) (BvaddNode op1ast op2ast),
       SetFlag Adjust (AssertNode "Adjust flag unimplemented"),
@@ -30,8 +33,8 @@ add_s inst =
 sub_s :: CsInsn -> [AstNodeType]
 sub_s inst =
   let (op1 : op2 : _ ) = x86operands inst
-      op1ast = getOperandAst $ value op1
-      op2ast = getOperandAst $ value op2
+      op1ast = getOperandAst op1
+      op2ast = getOperandAst op2
   in [
       store_node (value op1) (BvsubNode op1ast op2ast),
       SetFlag Adjust (AssertNode "Adjust flag unimplemented"),
@@ -45,8 +48,8 @@ sub_s inst =
 xor_s :: CsInsn -> [AstNodeType]
 xor_s inst =
   let (op1 : op2 : _ ) = x86operands inst
-      op1ast = getOperandAst $ value op1
-      op2ast = getOperandAst $ value op2
+      op1ast = getOperandAst op1
+      op2ast = getOperandAst op2
   in [
       store_node (value op1) (BvxorNode op1ast op2ast),
       SetFlag Adjust (AssertNode "Adjust flag unimplemented"),
@@ -59,10 +62,11 @@ xor_s inst =
 
 push ::  CsInsn -> [AstNodeType]
 push inst =
-  let op1 = getOperandAst $ get_first_opr_value inst
+  let (op1 : _) = x86operands inst
+      op1ast = getOperandAst op1
   in [
       SetReg stack_register (BvsubNode (GetReg stack_register) (BvNode 4 32)),
-      Store (GetReg stack_register) op1
+      Store (GetReg stack_register) op1ast
     ]
 
 pop ::  CsInsn -> [AstNodeType]
@@ -81,7 +85,7 @@ mov inst =
   let
     (op1 : op2 : _ ) = x86operands inst
   in
-    [store_node (value op1) (getOperandAst (value op2))]
+    [store_node (value op1) (getOperandAst op2)]
 
 
 getCsX86arch :: Maybe CsDetail -> Maybe CsX86


### PR DESCRIPTION
I have fully implemented add_s, but I have not yet tested it. I will probably begin testing after a few more basic instructions have been implemented.

Notice that add_node is used in several places (once for the main computation, and then a few more times to compute the values of the flags). If the resulting IR were to be interpreted, this would imply that the addition operation is re-evaluated several times. Probably tomorrow, I will make a mechanism to reference past expressions.