### PR TITLE
More x86 semantics

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -1,11 +1,7 @@
 module Ast where
 
 import Data.Word
-import           Hapstone.Internal.X86      as X86
-
---for now hapstone definition
-data Register = X86Reg X86.X86Reg -- Name String
-              deriving (Eq, Show)
+import Hapstone.Internal.X86 as X86
 
 data Flags = Zero
             | Overflow
@@ -17,22 +13,22 @@ data Flags = Zero
               deriving (Eq, Show)
 
 data AstNode = BvaddNode AstNode AstNode
-             | BvandNode  AstNode AstNode
-             | BvashrNode  AstNode AstNode
-             | BvlshrNode  AstNode AstNode
-             | BvmulNode  AstNode AstNode
-             | BvnandNode  AstNode AstNode
-             | BvnegNode  AstNode
-             | BvnorNode  AstNode AstNode
-             | BvnotNode  AstNode
-             | BvorNode  AstNode AstNode
-             | BvrolNode  AstNode AstNode
-             | BvrorNode  AstNode AstNode -- can lit
-             | BvsdivNode  AstNode AstNode
-             | BvsgeNode  AstNode AstNode
-             | BvsgtNode  AstNode AstNode
-             | BvshlNode  AstNode AstNode
-             | BvsleNode  AstNode AstNode
+             | BvandNode AstNode AstNode
+             | BvashrNode AstNode AstNode
+             | BvlshrNode AstNode AstNode
+             | BvmulNode AstNode AstNode
+             | BvnandNode AstNode AstNode
+             | BvnegNode AstNode
+             | BvnorNode AstNode AstNode
+             | BvnotNode AstNode
+             | BvorNode AstNode AstNode
+             | BvrolNode AstNode AstNode
+             | BvrorNode AstNode AstNode -- can lit
+             | BvsdivNode AstNode AstNode
+             | BvsgeNode AstNode AstNode
+             | BvsgtNode AstNode AstNode
+             | BvshlNode AstNode AstNode
+             | BvsleNode AstNode AstNode
              | BvsltNode AstNode AstNode
              | BvsmodNode AstNode AstNode
              | BvsremNode AstNode AstNode
@@ -68,46 +64,11 @@ data AstNode = BvaddNode AstNode AstNode
              -- nodes fow low level
              | Store AstNode AstNode
              | Read AstNode
-             | SetReg Register AstNode
-             | GetReg Register
+             | SetReg X86.X86Reg AstNode
+             | GetReg X86.X86Reg
              | SetFlag Flags AstNode
              | GetFlag Flags
 
              | AssertNode String -- errormsg
              deriving (Eq, Show)
 
-
-    -- //! `(let ((<alias> <expr2>)) <expr3>)`
-    -- class LetNode : public AbstractNode {
-    --   public:
-    --     TRITON_EXPORT LetNode(std::string alias, const SharedAbstractNode& expr2, const SharedAbstractNode& expr3);
-    --     TRITON_EXPORT void init(void);
-    --     TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
-    -- };
-    --
-    --
-    --
-    -- //! Reference node
-    -- class ReferenceNode : public AbstractNode {
-    --   protected:
-    --     triton::engines::symbolic::SharedSymbolicExpression expr;
-    --
-    --   public:
-    --     TRITON_EXPORT ReferenceNode(const triton::engines::symbolic::SharedSymbolicExpression& expr);
-    --     TRITON_EXPORT void init(void);
-    --     TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
-    --     TRITON_EXPORT const triton::engines::symbolic::SharedSymbolicExpression& getSymbolicExpression(void) const;
-    -- };
-    --
-    --
-    -- //! Variable node
-    -- class VariableNode : public AbstractNode {
-    --   protected:
-    --     triton::engines::symbolic::SharedSymbolicVariable symVar;
-    --
-    --   public:
-    --     TRITON_EXPORT VariableNode(const triton::engines::symbolic::SharedSymbolicVariable& symVar, AstContext& ctxt);
-    --     TRITON_EXPORT void init(void);
-    --     TRITON_EXPORT triton::uint512 hash(triton::uint32 deep) const;
-    --     TRITON_EXPORT const triton::engines::symbolic::SharedSymbolicVariable& getVar(void);
-    -- };

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -12,63 +12,64 @@ data Flags = Zero
             | Direction
               deriving (Eq, Show)
 
-data AstNode = BvaddNode AstNode AstNode
-             | BvandNode AstNode AstNode
-             | BvashrNode AstNode AstNode
-             | BvlshrNode AstNode AstNode
-             | BvmulNode AstNode AstNode
-             | BvnandNode AstNode AstNode
-             | BvnegNode AstNode
-             | BvnorNode AstNode AstNode
-             | BvnotNode AstNode
-             | BvorNode AstNode AstNode
-             | BvrolNode AstNode AstNode
-             | BvrorNode AstNode AstNode -- can lit
-             | BvsdivNode AstNode AstNode
-             | BvsgeNode AstNode AstNode
-             | BvsgtNode AstNode AstNode
-             | BvshlNode AstNode AstNode
-             | BvsleNode AstNode AstNode
-             | BvsltNode AstNode AstNode
-             | BvsmodNode AstNode AstNode
-             | BvsremNode AstNode AstNode
-             | BvsubNode AstNode AstNode
-             | BvudivNode AstNode AstNode
-             | BvugeNode AstNode AstNode
-             | BvugtNode AstNode AstNode
-             | BvuleNode AstNode AstNode
-             | BvultNode AstNode AstNode
-             | BvuremNode AstNode AstNode
-             | BvxnorNode AstNode AstNode
-             | BvxorNode AstNode AstNode
-             | BvNode Word64 Word8
-             | CompoundNode -- ! `[<expr1> <expr2> <expr3> ...]` node
-             | ConcatNode [AstNode]
-             | DecimalNode Int --float?
-             | DeclareNode --wtf?
-             | DistinctNode AstNode AstNode
-             | EqualNode AstNode AstNode
-             | ExtractNode Word8 Word8 AstNode -- ! `((_ extract <high> <low>) <expr>)` node
-             | IffNode AstNode AstNode -- ! `(iff <expr1> <expr2>)`
-             | IteNode AstNode AstNode AstNode -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
-             | LandNode AstNode AstNode
-             | LetNode String AstNode AstNode
-             | LnotNode AstNode
-             | LorNode AstNode AstNode
-             | ReferenceNode --fix
-             | StringNode String
-             | SxNode Int AstNode
-             | VariableNode
-             | ZxNode Int AstNode
-             | UndefinedNode -- The undefined value
-             -- nodes fow low level
-             | Store AstNode AstNode
-             | Read AstNode
-             | SetReg X86.X86Reg AstNode
-             | GetReg X86.X86Reg
-             | SetFlag Flags AstNode
-             | GetFlag Flags
+data AstNode =
+    BvaddNode AstNode AstNode
+  | BvandNode AstNode AstNode
+  | BvashrNode AstNode AstNode
+  | BvlshrNode AstNode AstNode
+  | BvmulNode AstNode AstNode
+  | BvnandNode AstNode AstNode
+  | BvnegNode AstNode
+  | BvnorNode AstNode AstNode
+  | BvnotNode AstNode
+  | BvorNode AstNode AstNode
+  | BvrolNode AstNode AstNode
+  | BvrorNode AstNode AstNode -- can lit
+  | BvsdivNode AstNode AstNode
+  | BvsgeNode AstNode AstNode
+  | BvsgtNode AstNode AstNode
+  | BvshlNode AstNode AstNode
+  | BvsleNode AstNode AstNode
+  | BvsltNode AstNode AstNode
+  | BvsmodNode AstNode AstNode
+  | BvsremNode AstNode AstNode
+  | BvsubNode AstNode AstNode
+  | BvudivNode AstNode AstNode
+  | BvugeNode AstNode AstNode
+  | BvugtNode AstNode AstNode
+  | BvuleNode AstNode AstNode
+  | BvultNode AstNode AstNode
+  | BvuremNode AstNode AstNode
+  | BvxnorNode AstNode AstNode
+  | BvxorNode AstNode AstNode
+  | BvNode Word64 Word8
+  | CompoundNode -- ! `[<expr1> <expr2> <expr3> ...]` node
+  | ConcatNode [AstNode]
+  | DecimalNode Int --float?
+  | DeclareNode --wtf?
+  | DistinctNode AstNode AstNode
+  | EqualNode AstNode AstNode
+  | ExtractNode Word8 Word8 AstNode -- ! `((_ extract <high> <low>) <expr>)` node
+  | IffNode AstNode AstNode -- ! `(iff <expr1> <expr2>)`
+  | IteNode AstNode AstNode AstNode -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
+  | LandNode AstNode AstNode
+  | LetNode String AstNode AstNode
+  | LnotNode AstNode
+  | LorNode AstNode AstNode
+  | ReferenceNode --fix
+  | StringNode String
+  | SxNode Int AstNode
+  | VariableNode
+  | ZxNode Int AstNode
+  | UndefinedNode -- The undefined value
+  | Read AstNode
+  | GetReg X86.X86Reg
+  | GetFlag Flags
+  deriving (Eq, Show)
 
-             | AssertNode String -- errormsg
-             deriving (Eq, Show)
+data Stmt =
+    Store AstNode AstNode
+  | SetReg X86.X86Reg AstNode
+  | SetFlag Flags AstNode
+  deriving (Eq, Show)
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -16,61 +16,61 @@ data Flags = Zero
             | Direction
               deriving (Eq, Show)
 
-data AstNodeType = BvaddNode AstNodeType AstNodeType
-             | BvandNode  AstNodeType AstNodeType
-             | BvashrNode  AstNodeType AstNodeType
-             | BvlshrNode  AstNodeType AstNodeType
-             | BvmulNode  AstNodeType AstNodeType
-             | BvnandNode  AstNodeType AstNodeType
-             | BvnegNode  AstNodeType
-             | BvnorNode  AstNodeType AstNodeType
-             | BvnotNode  AstNodeType
-             | BvorNode  AstNodeType AstNodeType
-             | BvrolNode  AstNodeType AstNodeType
-             | BvrorNode  AstNodeType AstNodeType -- can lit
-             | BvsdivNode  AstNodeType AstNodeType
-             | BvsgeNode  AstNodeType AstNodeType
-             | BvsgtNode  AstNodeType AstNodeType
-             | BvshlNode  AstNodeType AstNodeType
-             | BvsleNode  AstNodeType AstNodeType
-             | BvsltNode AstNodeType AstNodeType
-             | BvsmodNode AstNodeType AstNodeType
-             | BvsremNode AstNodeType AstNodeType
-             | BvsubNode AstNodeType AstNodeType
-             | BvudivNode AstNodeType AstNodeType
-             | BvugeNode AstNodeType AstNodeType
-             | BvugtNode AstNodeType AstNodeType
-             | BvuleNode AstNodeType AstNodeType
-             | BvultNode AstNodeType AstNodeType
-             | BvuremNode AstNodeType AstNodeType
-             | BvxnorNode AstNodeType AstNodeType
-             | BvxorNode AstNodeType AstNodeType
+data AstNode = BvaddNode AstNode AstNode
+             | BvandNode  AstNode AstNode
+             | BvashrNode  AstNode AstNode
+             | BvlshrNode  AstNode AstNode
+             | BvmulNode  AstNode AstNode
+             | BvnandNode  AstNode AstNode
+             | BvnegNode  AstNode
+             | BvnorNode  AstNode AstNode
+             | BvnotNode  AstNode
+             | BvorNode  AstNode AstNode
+             | BvrolNode  AstNode AstNode
+             | BvrorNode  AstNode AstNode -- can lit
+             | BvsdivNode  AstNode AstNode
+             | BvsgeNode  AstNode AstNode
+             | BvsgtNode  AstNode AstNode
+             | BvshlNode  AstNode AstNode
+             | BvsleNode  AstNode AstNode
+             | BvsltNode AstNode AstNode
+             | BvsmodNode AstNode AstNode
+             | BvsremNode AstNode AstNode
+             | BvsubNode AstNode AstNode
+             | BvudivNode AstNode AstNode
+             | BvugeNode AstNode AstNode
+             | BvugtNode AstNode AstNode
+             | BvuleNode AstNode AstNode
+             | BvultNode AstNode AstNode
+             | BvuremNode AstNode AstNode
+             | BvxnorNode AstNode AstNode
+             | BvxorNode AstNode AstNode
              | BvNode Word64 Word8
              | CompoundNode -- ! `[<expr1> <expr2> <expr3> ...]` node
-             | ConcatNode [AstNodeType]
+             | ConcatNode [AstNode]
              | DecimalNode Int --float?
              | DeclareNode --wtf?
-             | DistinctNode AstNodeType AstNodeType
-             | EqualNode AstNodeType AstNodeType
-             | ExtractNode Word8 Word8  AstNodeType -- ! `((_ extract <high> <low>) <expr>)` node
-             | IffNode AstNodeType AstNodeType -- ! `(iff <expr1> <expr2>)`
-             | IteNode AstNodeType AstNodeType AstNodeType -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
-             | LandNode AstNodeType AstNodeType
-             | LetNode String AstNodeType AstNodeType
-             | LnotNode AstNodeType
-             | LorNode AstNodeType AstNodeType
+             | DistinctNode AstNode AstNode
+             | EqualNode AstNode AstNode
+             | ExtractNode Word8 Word8  AstNode -- ! `((_ extract <high> <low>) <expr>)` node
+             | IffNode AstNode AstNode -- ! `(iff <expr1> <expr2>)`
+             | IteNode AstNode AstNode AstNode -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
+             | LandNode AstNode AstNode
+             | LetNode String AstNode AstNode
+             | LnotNode AstNode
+             | LorNode AstNode AstNode
              | ReferenceNode --fix
              | StringNode String
-             | SxNode Int AstNodeType
+             | SxNode Int AstNode
              | VariableNode
-             | ZxNode Int AstNodeType
+             | ZxNode Int AstNode
              | UndefinedNode -- The undefined value
              -- nodes fow low level
-             | Store AstNodeType AstNodeType
-             | Read AstNodeType
-             | SetReg Register AstNodeType
+             | Store AstNode AstNode
+             | Read AstNode
+             | SetReg Register AstNode
              | GetReg Register
-             | SetFlag Flags AstNodeType
+             | SetFlag Flags AstNode
              | GetFlag Flags
 
              | AssertNode String -- errormsg

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -64,6 +64,7 @@ data AstNodeType = BvaddNode AstNodeType AstNodeType
              | SxNode Int AstNodeType
              | VariableNode
              | ZxNode Int AstNodeType
+             | UndefinedNode -- The undefined value
              -- nodes fow low level
              | Store AstNodeType AstNodeType
              | Read AstNodeType

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -48,7 +48,7 @@ data AstNode = BvaddNode AstNode AstNode
              | DeclareNode --wtf?
              | DistinctNode AstNode AstNode
              | EqualNode AstNode AstNode
-             | ExtractNode Word8 Word8  AstNode -- ! `((_ extract <high> <low>) <expr>)` node
+             | ExtractNode Word8 Word8 AstNode -- ! `((_ extract <high> <low>) <expr>)` node
              | IffNode AstNode AstNode -- ! `(iff <expr1> <expr2>)`
              | IteNode AstNode AstNode AstNode -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
              | LandNode AstNode AstNode

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -10,7 +10,7 @@ import           Data.Word
 getOperandAst :: CsX86Op -> AstNode
 getOperandAst op = case value op of
   (Imm value) -> BvNode value ((size op) * 8)
-  (Reg reg) -> GetReg (X86Reg reg)
+  (Reg reg) -> GetReg reg
   (Mem mem) -> Read (getLeaAst mem)
 
 
@@ -19,9 +19,9 @@ getLeaAst mem =
     (BvaddNode node_disp (BvaddNode node_base node_index) ) where
         node_base = case base mem of
             X86RegInvalid -> (BvNode 0 32)
-            reg -> GetReg (X86Reg reg)
+            reg -> GetReg reg
         node_index = case index mem of
             X86RegInvalid -> (BvNode 0 32)
             reg ->
-              BvmulNode (GetReg (X86Reg reg)) (BvNode (fromIntegral $ scale mem) 32)
+              BvmulNode (GetReg reg) (BvNode (fromIntegral $ scale mem) 32)
         node_disp = BvNode (fromIntegral $ disp' mem) 32

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -7,14 +7,14 @@ import           Hapstone.Internal.Capstone as Capstone
 import           Hapstone.Internal.X86      as X86
 import           Data.Word
 
-getOperandAst :: CsX86Op -> AstNodeType
+getOperandAst :: CsX86Op -> AstNode
 getOperandAst op = case value op of
   (Imm value) -> BvNode value ((size op) * 8)
   (Reg reg) -> GetReg (X86Reg reg)
   (Mem mem) -> Read (getLeaAst mem)
 
 
-getLeaAst :: X86OpMemStruct -> AstNodeType
+getLeaAst :: X86OpMemStruct -> AstNode
 getLeaAst mem =
     (BvaddNode node_disp (BvaddNode node_base node_index) ) where
         node_base = case base mem of

--- a/src/AstTools.hs
+++ b/src/AstTools.hs
@@ -2,7 +2,7 @@ module AstTools where
 
 import Ast
 
-filter_out_flags :: [[AstNodeType]] -> [[AstNodeType]]
+filter_out_flags :: [[AstNode]] -> [[AstNode]]
 filter_out_flags asttree =
   --just used for some test, shouldn't be used in code as its not correct
   map (\x ->
@@ -11,3 +11,4 @@ filter_out_flags asttree =
       _ -> True
       ) x
     ) asttree
+

--- a/src/AstTools.hs
+++ b/src/AstTools.hs
@@ -2,7 +2,7 @@ module AstTools where
 
 import Ast
 
-filter_out_flags :: [[AstNode]] -> [[AstNode]]
+filter_out_flags :: [[Stmt]] -> [[Stmt]]
 filter_out_flags asttree =
   --just used for some test, shouldn't be used in code as its not correct
   map (\x ->

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -23,11 +23,11 @@ newX86Context =
                   memory = []
                 }
 
-eval :: ExecutionContext -> [AstNodeType] -> ExecutionContext
+eval :: ExecutionContext -> [AstNode] -> ExecutionContext
 eval cin ast =
           cin
 
 -- by default all undefined regs are symbolic?
-symbolicEval :: ExecutionContext -> [AstNodeType] -> ExecutionContext
+symbolicEval :: ExecutionContext -> [AstNode] -> ExecutionContext
 symbolicEval cin ast =
           cin

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -1,6 +1,7 @@
 module EvalAst where
 
 import Ast
+import Hapstone.Internal.X86 as X86
 
 -- data Context = {
 --       registers = [...],
@@ -12,7 +13,7 @@ import qualified Data.Map.Strict as Map
 data MemRegions = Lol
 
 data ExecutionContext = ExecutionContext {
-        registers :: (Map.Map Register Int)
+        registers :: (Map.Map X86.X86Reg Int)
       , memory :: [MemRegions]
 }
 

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -2,31 +2,47 @@ module EvalAst where
 
 import Ast
 import Hapstone.Internal.X86 as X86
-
--- data Context = {
---       registers = [...],
---       memory = [...]
--- }
-
-import qualified Data.Map.Strict as Map
-
-data MemRegions = Lol
+import Util
+import Data.Bits
 
 data ExecutionContext = ExecutionContext {
-        registers :: (Map.Map X86.X86Reg Int)
-      , memory :: [MemRegions]
+  registers :: [(X86.X86Reg, Int)],
+  memory :: [(Int, Int)]
 }
 
 newX86Context :: ExecutionContext
-newX86Context =
-                ExecutionContext {
-                  registers = Map.empty,
-                  memory = []
-                }
+newX86Context = ExecutionContext {
+  registers = [],
+  memory = []
+}
 
-eval :: ExecutionContext -> [AstNode] -> ExecutionContext
-eval cin ast =
-          cin
+-- Evaluates the given node in the given context and returns the result
+
+eval :: ExecutionContext -> AstNode -> Int
+
+eval cin (BvNode a _) = convert a
+
+eval cin (BvxorNode a b) = convert (xor (eval cin a) (eval cin b))
+
+eval cin (BvandNode a b) = convert ((eval cin a) .&. (eval cin b))
+
+eval cin (BvorNode a b) = convert ((eval cin a) .|. (eval cin b))
+
+eval cin (BvaddNode a b) = convert ((eval cin a) + (eval cin b))
+
+eval cin (BvsubNode a b) = convert ((eval cin a) - (eval cin b))
+
+eval cin (ExtractNode a b c) =
+  convert ((shift (eval cin c) (convert (-b))) .&. ((2 ^ convert (a + 1 - b)) - 1))
+
+eval cin (GetReg reg) =
+  case lookup reg (registers cin) of
+    Just x -> x
+    Nothing -> error "Invalid x86 context."
+
+-- Executes the given statement in the given context and returns a new context
+
+--exec :: ExecutionContext -> AstNode -> ExecutionContext
 
 -- by default all undefined regs are symbolic?
 symbolicEval :: ExecutionContext -> [AstNode] -> ExecutionContext

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -1,15 +1,15 @@
 module Lifter where
 
-import            Ast
-import            X86Sem
-import            Hapstone.Capstone
-import            Hapstone.Internal.Capstone as Capstone
-import            Hapstone.Internal.X86      as X86
-import            Util
-import            Data.Word
+import Ast
+import X86Sem
+import Hapstone.Capstone
+import Hapstone.Internal.Capstone as Capstone
+import Hapstone.Internal.X86      as X86
+import Util
+import Data.Word
 
 --x86 vs arm, etc?
-mmp :: [CsMode] -> CsInsn -> [AstNode]
+mmp :: [CsMode] -> CsInsn -> [Stmt]
 mmp modes a = case toEnum (fromIntegral (insnId a)) of
   X86InsAdd -> add_s a
   X86InsMov -> mov a
@@ -19,17 +19,18 @@ mmp modes a = case toEnum (fromIntegral (insnId a)) of
   X86InsXor -> xor_s a
   X86InsAnd -> and_s a
   X86InsOr -> or_s a
-  otherwise -> [AssertNode (mnemonic a)]
+  otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported.")
 
-liftAsm :: [CsMode] -> [CsInsn] -> [[AstNode]]
+liftAsm :: [CsMode] -> [CsInsn] -> [[Stmt]]
 liftAsm modes buf = map (mmp modes) buf
 
 disasm_buf :: [CsMode] -> [Word8] -> IO (Either CsErr [CsInsn])
 disasm_buf modes buffer = disasmSimpleIO $ disasm modes buffer 0
 
-liftX86toAst :: [CsMode] -> [Word8] -> IO [[AstNode]]
+liftX86toAst :: [CsMode] -> [Word8] -> IO [[Stmt]]
 liftX86toAst modes input = do
     asm <- disasm_buf modes input
     return (case asm of
-      Left _ -> [[(AssertNode "dissasm error")]]
+      Left _ -> error "Error in disassembling machine code."
       Right b -> liftAsm modes b)
+

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -9,7 +9,7 @@ import            Util
 import            Data.Word
 
 --x86 vs arm, etc?
-mmp :: [CsMode] -> CsInsn -> [AstNodeType]
+mmp :: [CsMode] -> CsInsn -> [AstNode]
 mmp modes a = case toEnum (fromIntegral (insnId a)) of
   X86InsAdd -> add_s a
   X86InsMov -> mov a
@@ -19,13 +19,13 @@ mmp modes a = case toEnum (fromIntegral (insnId a)) of
   X86InsXor -> xor_s a
   otherwise -> [AssertNode (mnemonic a)]
 
-liftAsm :: [CsMode] -> [CsInsn] -> [[AstNodeType]]
+liftAsm :: [CsMode] -> [CsInsn] -> [[AstNode]]
 liftAsm modes buf = map (mmp modes) buf
 
 disasm_buf :: [CsMode] -> [Word8] -> IO (Either CsErr [CsInsn])
 disasm_buf modes buffer = disasmSimpleIO $ disasm modes buffer 0
 
-liftX86toAst :: [CsMode] -> [Word8] -> IO [[AstNodeType]]
+liftX86toAst :: [CsMode] -> [Word8] -> IO [[AstNode]]
 liftX86toAst modes input = do
     asm <- disasm_buf modes input
     return (case asm of

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -14,6 +14,9 @@ mmp modes a = case toEnum (fromIntegral (insnId a)) of
           X86InsAdd -> add_s a
           X86InsMov -> mov a
           X86InsSub -> sub_s a
+          X86InsPush -> push_s a
+          X86InsPop -> pop_s a
+          X86InsXor -> xor_s a
           otherwise -> [AssertNode (mnemonic a)]
 
 liftAsm :: [CsMode] -> [CsInsn] -> [[AstNodeType]]

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -14,8 +14,8 @@ mmp modes a = case toEnum (fromIntegral (insnId a)) of
   X86InsAdd -> add_s a
   X86InsMov -> mov a
   X86InsSub -> sub_s a
-  X86InsPush -> push_s a
-  X86InsPop -> pop_s a
+  X86InsPush -> push_s modes a
+  X86InsPop -> pop_s modes a
   X86InsXor -> xor_s a
   otherwise -> [AssertNode (mnemonic a)]
 

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -17,6 +17,8 @@ mmp modes a = case toEnum (fromIntegral (insnId a)) of
   X86InsPush -> push_s modes a
   X86InsPop -> pop_s modes a
   X86InsXor -> xor_s a
+  X86InsAnd -> and_s a
+  X86InsOr -> or_s a
   otherwise -> [AssertNode (mnemonic a)]
 
 liftAsm :: [CsMode] -> [CsInsn] -> [[AstNode]]

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -11,13 +11,13 @@ import            Data.Word
 --x86 vs arm, etc?
 mmp :: [CsMode] -> CsInsn -> [AstNodeType]
 mmp modes a = case toEnum (fromIntegral (insnId a)) of
-          X86InsAdd -> add_s a
-          X86InsMov -> mov a
-          X86InsSub -> sub_s a
-          X86InsPush -> push_s a
-          X86InsPop -> pop_s a
-          X86InsXor -> xor_s a
-          otherwise -> [AssertNode (mnemonic a)]
+  X86InsAdd -> add_s a
+  X86InsMov -> mov a
+  X86InsSub -> sub_s a
+  X86InsPush -> push_s a
+  X86InsPop -> pop_s a
+  X86InsXor -> xor_s a
+  otherwise -> [AssertNode (mnemonic a)]
 
 liftAsm :: [CsMode] -> [CsInsn] -> [[AstNodeType]]
 liftAsm modes buf = map (mmp modes) buf

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import qualified Data.ByteString            as BS
 import           System.IO
+import           Hapstone.Internal.Capstone as Capstone
 
 import Lifter
 --import Simplify
@@ -10,11 +11,12 @@ main :: IO ()
 main = do
   -- contents <- BS.readFile "bs/blackcipher.aes"
   print "this should be in test/"
-  let input = [0x04, 0x0A]
-  asm <- disasm_buf input
+  let input = [0x83, 0xE8, 0x05]
+  let modes = [Capstone.CsMode32]
+  asm <- disasm_buf modes input
   case asm of
     Left _ -> print "error"
-    Right b -> print (liftAsm b)
+    Right b -> print (liftAsm modes b)
   -- let simplification = Simplify { buffer = first_pass }
 
   -- state <- lift_next_block $ new_state contents

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -11,10 +11,10 @@ import           Numeric                    (showHex)
 getBinPart :: BS.ByteString -> Int -> Int -> [Word8]
 getBinPart contents from cnt = BS.unpack $ BS.take cnt $ BS.drop from contents
 
-disasm :: [Word8] -> Word64 -> Disassembler ()
-disasm intel_asm_buf start_addr = Disassembler {
+disasm :: [CsMode] -> [Word8] -> Word64 -> Disassembler ()
+disasm modes intel_asm_buf start_addr = Disassembler {
     arch = Capstone.CsArchX86 -- ^ Options: CsArchArm, CsArchArm64, CsArchMips, CsArchX86, CsArchPpc, CsArchSparc, CsArchSysz, CsArchXcore
-    , modes = [Capstone.CsMode32] -- ^ Modes (some may be combined by adding to the list): CsModeLittleEndian, CsModeArm, CsMode16 (16-bit x86), CsMode32 (32-bit x86), CsMode64 (64-bit x86-64/amd64 or PPC), CsModeThumb, CsModeMclass, CsModeV8 (ARMv8 A32), CsModeMicro, CsModeMips3, CsModeMips32r6, CsModeMipsGp64, CsModeV9 (SparcV9 mode), CsModeBigEndian, CsModeMips32, CsModeMips64
+    , modes = modes -- ^ Modes (some may be combined by adding to the list): CsModeLittleEndian, CsModeArm, CsMode16 (16-bit x86), CsMode32 (32-bit x86), CsMode64 (64-bit x86-64/amd64 or PPC), CsModeThumb, CsModeMclass, CsModeV8 (ARMv8 A32), CsModeMicro, CsModeMips3, CsModeMips32r6, CsModeMipsGp64, CsModeV9 (SparcV9 mode), CsModeBigEndian, CsModeMips32, CsModeMips64
     , buffer = intel_asm_buf -- ^ buffer to disassemble, as [Word8]
     , addr = start_addr -- ^ address of first byte in the buffer, as Word64
     , num = 0 -- ^ number of instructions to disassemble (0 for maximum)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -63,3 +63,9 @@ contains_group gr insn = case Capstone.detail insn of
   Just d  -> do
     let grw8 = fromIntegral(fromEnum gr) :: Word8
     List.elem grw8 $ groups d
+
+-- Convert instance of integral type to instance of some numerical type
+
+convert :: Integral a => Num b => a -> b
+convert a = (fromInteger (toInteger a))
+

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -142,19 +142,22 @@ sub_s inst =
       SetFlag Overflow (of_sub_s inst sub_node op1 op1ast op1ast)
     ]
 
+-- Make list of operations in the IR that has the same semantics as the X86 xor instruction
+
 xor_s :: CsInsn -> [AstNodeType]
 xor_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
       op2ast = getOperandAst op2
+      xor_node = (BvxorNode op1ast op2ast)
   in [
-      store_node (value op1) (BvxorNode op1ast op2ast),
-      SetFlag Adjust (AssertNode "Adjust flag unimplemented"),
-      SetFlag Parity (AssertNode "Parity flag unimplemented"),
-      SetFlag Sign (AssertNode "Sign flag unimplemented"),
-      SetFlag Zero (AssertNode "Zero flag unimplemented"),
-      SetFlag Carry (AssertNode "Carry flag unimplemented"),
-      SetFlag Overflow (AssertNode "Overflow flag unimplemented")
+      store_node (value op1) xor_node,
+      SetFlag Adjust UndefinedNode,
+      SetFlag Parity (pf_s inst xor_node op1),
+      SetFlag Sign (sf_s inst xor_node op1),
+      SetFlag Zero (zf_s inst xor_node op1),
+      SetFlag Carry (BvNode 0 1),
+      SetFlag Overflow (BvNode 0 1)
     ]
 
 push ::  CsInsn -> [AstNodeType]

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -20,6 +20,108 @@ dqword_size_bit = 128
 qqword_size_bit = 256
 dqqword_size_bit = 512
 
+-- Given the target processor mode, get the largest register containing this register
+
+get_parent_register :: [CsMode] -> X86Reg -> X86Reg
+
+get_parent_register modes reg | elem CsMode16 modes =
+  case reg of
+    X86RegAl -> X86RegAx
+    X86RegAh -> X86RegAx
+    X86RegBl -> X86RegBx
+    X86RegBh -> X86RegBx
+    X86RegCl -> X86RegCx
+    X86RegCh -> X86RegCx
+    X86RegDl -> X86RegDx
+    X86RegDh -> X86RegDx
+    X86RegDil -> X86RegDi
+    X86RegSil -> X86RegSi
+    X86RegBpl -> X86RegBp
+    X86RegSpl -> X86RegSp
+    --X86RegR8l -> X86RegR8w
+    --X86RegR9l -> X86RegR9w
+    --X86RegR10l -> X86RegR10w
+    --X86RegR11l -> X86RegR11w
+    --X86RegR12l -> X86RegR12w
+    --X86RegR13l -> X86RegR13w
+    --X86RegR14l -> X86RegR14w
+    --X86RegR15l -> X86RegR15w
+    otherwise -> otherwise
+
+get_parent_register modes reg | elem CsMode32 modes =
+  case get_parent_register [CsMode16] reg of
+    X86RegAx -> X86RegEax
+    X86RegBx -> X86RegEbx
+    X86RegCx -> X86RegEcx
+    X86RegDx -> X86RegEdx
+    X86RegBp -> X86RegEbp
+    X86RegSi -> X86RegEsi
+    X86RegDi -> X86RegEdi
+    X86RegSp -> X86RegEsp
+    X86RegR8w -> X86RegR8d
+    X86RegR9w -> X86RegR9d
+    X86RegR10w -> X86RegR10d
+    X86RegR11w -> X86RegR11d
+    X86RegR12w -> X86RegR12d
+    X86RegR13w -> X86RegR13d
+    X86RegR14w -> X86RegR14d
+    X86RegR15w -> X86RegR15d
+    otherwise -> otherwise
+
+get_parent_register modes reg | elem CsMode64 modes =
+  case get_parent_register [CsMode32] reg of
+    X86RegEax -> X86RegRax
+    X86RegEbx -> X86RegRbx
+    X86RegEcx -> X86RegRcx
+    X86RegEdx -> X86RegRdx
+    X86RegEbp -> X86RegRbp
+    X86RegEsi -> X86RegRsi
+    X86RegEdi -> X86RegRdi
+    X86RegEsp -> X86RegRsp
+    X86RegR8d -> X86RegR8
+    X86RegR9d -> X86RegR9
+    X86RegR10d -> X86RegR10
+    X86RegR11d -> X86RegR11
+    X86RegR12d -> X86RegR12
+    X86RegR13d -> X86RegR13
+    X86RegR14d -> X86RegR14
+    X86RegR15d -> X86RegR15
+    otherwise -> otherwise
+
+-- Checks if the given register is a segment register
+
+is_segment_reg :: X86.X86Reg -> Bool
+is_segment_reg reg = case reg of
+  X86RegCs -> True
+  X86RegDs -> True
+  X86RegSs -> True
+  X86RegEs -> True
+  X86RegFs -> True
+  X86RegGs -> True
+  _ -> False
+
+-- Checks if the given register is a control register
+
+is_control_reg :: X86.X86Reg -> Bool
+is_control_reg reg = case reg of
+  X86RegCr0 -> True
+  X86RegCr1 -> True
+  X86RegCr2 -> True
+  X86RegCr3 -> True
+  X86RegCr4 -> True
+  X86RegCr5 -> True
+  X86RegCr6 -> True
+  X86RegCr7 -> True
+  X86RegCr8 -> True
+  X86RegCr9 -> True
+  X86RegCr10 -> True
+  X86RegCr11 -> True
+  X86RegCr12 -> True
+  X86RegCr13 -> True
+  X86RegCr14 -> True
+  X86RegCr15 -> True
+  _ -> False
+
 -- Make operation to set the zero flag to the value that it would have after some operation
 
 zf_s :: AstNode -> CsX86Op -> AstNode
@@ -152,16 +254,52 @@ sub_s inst =
 
 xor_s :: CsInsn -> [AstNode]
 xor_s inst =
-  let (op1 : op2 : _ ) = x86operands inst
-      op1ast = getOperandAst op1
-      op2ast = getOperandAst op2
-      xor_node = (BvxorNode op1ast op2ast)
+  let (dst_op : src_op : _ ) = x86operands inst
+      dst_ast = getOperandAst dst_op
+      src_ast = getOperandAst src_op
+      xor_node = (BvxorNode dst_ast src_ast)
   in [
-      store_node (value op1) xor_node,
+      store_node (value dst_op) xor_node,
       SetFlag Adjust UndefinedNode,
-      SetFlag Parity (pf_s xor_node op1),
-      SetFlag Sign (sf_s xor_node op1),
-      SetFlag Zero (zf_s xor_node op1),
+      SetFlag Parity (pf_s xor_node dst_op),
+      SetFlag Sign (sf_s xor_node dst_op),
+      SetFlag Zero (zf_s xor_node dst_op),
+      SetFlag Carry (BvNode 0 1),
+      SetFlag Overflow (BvNode 0 1)
+    ]
+
+-- Make list of operations in the IR that has the same semantics as the X86 and instruction
+
+and_s :: CsInsn -> [AstNode]
+and_s inst =
+  let (dst_op : src_op : _ ) = x86operands inst
+      dst_ast = getOperandAst dst_op
+      src_ast = getOperandAst src_op
+      and_node = (BvandNode dst_ast src_ast)
+  in [
+      store_node (value dst_op) and_node,
+      SetFlag Adjust UndefinedNode,
+      SetFlag Parity (pf_s and_node dst_op),
+      SetFlag Sign (sf_s and_node dst_op),
+      SetFlag Zero (zf_s and_node dst_op),
+      SetFlag Carry (BvNode 0 1),
+      SetFlag Overflow (BvNode 0 1)
+    ]
+
+-- Make list of operations in the IR that has the same semantics as the X86 or instruction
+
+or_s :: CsInsn -> [AstNode]
+or_s inst =
+  let (dst_op : src_op : _ ) = x86operands inst
+      dst_ast = getOperandAst dst_op
+      src_ast = getOperandAst src_op
+      and_node = (BvorNode dst_ast src_ast)
+  in [
+      store_node (value dst_op) and_node,
+      SetFlag Adjust UndefinedNode,
+      SetFlag Parity (pf_s and_node dst_op),
+      SetFlag Sign (sf_s and_node dst_op),
+      SetFlag Zero (zf_s and_node dst_op),
       SetFlag Carry (BvNode 0 1),
       SetFlag Overflow (BvNode 0 1)
     ]
@@ -193,74 +331,6 @@ push_s modes inst =
 includeIf :: Bool -> [a] -> [a]
 includeIf cond sublist = if cond then sublist else []
 
--- Given the target processor mode, get the largest register containing this register
-
-get_parent_register :: [CsMode] -> X86Reg -> X86Reg
-
-get_parent_register modes reg | elem CsMode16 modes =
-  case reg of
-    X86RegAl -> X86RegAx
-    X86RegAh -> X86RegAx
-    X86RegBl -> X86RegBx
-    X86RegBh -> X86RegBx
-    X86RegCl -> X86RegCx
-    X86RegCh -> X86RegCx
-    X86RegDl -> X86RegDx
-    X86RegDh -> X86RegDx
-    X86RegDil -> X86RegDi
-    X86RegSil -> X86RegSi
-    X86RegBpl -> X86RegBp
-    X86RegSpl -> X86RegSp
-    --X86RegR8l -> X86RegR8w
-    --X86RegR9l -> X86RegR9w
-    --X86RegR10l -> X86RegR10w
-    --X86RegR11l -> X86RegR11w
-    --X86RegR12l -> X86RegR12w
-    --X86RegR13l -> X86RegR13w
-    --X86RegR14l -> X86RegR14w
-    --X86RegR15l -> X86RegR15w
-    otherwise -> otherwise
-
-get_parent_register modes reg | elem CsMode32 modes =
-  case get_parent_register [CsMode16] reg of
-    X86RegAx -> X86RegEax
-    X86RegBx -> X86RegEbx
-    X86RegCx -> X86RegEcx
-    X86RegDx -> X86RegEdx
-    X86RegBp -> X86RegEbp
-    X86RegSi -> X86RegEsi
-    X86RegDi -> X86RegEdi
-    X86RegSp -> X86RegEsp
-    X86RegR8w -> X86RegR8d
-    X86RegR9w -> X86RegR9d
-    X86RegR10w -> X86RegR10d
-    X86RegR11w -> X86RegR11d
-    X86RegR12w -> X86RegR12d
-    X86RegR13w -> X86RegR13d
-    X86RegR14w -> X86RegR14d
-    X86RegR15w -> X86RegR15d
-    otherwise -> otherwise
-
-get_parent_register modes reg | elem CsMode64 modes =
-  case get_parent_register [CsMode32] reg of
-    X86RegEax -> X86RegRax
-    X86RegEbx -> X86RegRbx
-    X86RegEcx -> X86RegRcx
-    X86RegEdx -> X86RegRdx
-    X86RegEbp -> X86RegRbp
-    X86RegEsi -> X86RegRsi
-    X86RegEdi -> X86RegRdi
-    X86RegEsp -> X86RegRsp
-    X86RegR8d -> X86RegR8
-    X86RegR9d -> X86RegR9
-    X86RegR10d -> X86RegR10
-    X86RegR11d -> X86RegR11
-    X86RegR12d -> X86RegR12
-    X86RegR13d -> X86RegR13
-    X86RegR14d -> X86RegR14
-    X86RegR15d -> X86RegR15
-    otherwise -> otherwise
-
 -- Make list of operations in the IR that has the same semantics as the X86 pop instruction
 
 pop_s :: [CsMode] -> CsInsn -> [AstNode]
@@ -283,39 +353,6 @@ pop_s modes inst =
     (includeIf sp_base [SetReg sp new_sp_val])
     ++ [store_node (value op1) (Read new_sp_val)]
     ++ (includeIf (not (sp_base || sp_reg)) [SetReg sp new_sp_val])
-
--- Checks if the given register is a segment register
-
-is_segment_reg :: X86.X86Reg -> Bool
-is_segment_reg reg = case reg of
-  X86RegCs -> True
-  X86RegDs -> True
-  X86RegSs -> True
-  X86RegEs -> True
-  X86RegFs -> True
-  X86RegGs -> True
-  _ -> False
-
--- Checks if the given register is a control register
-
-is_control_reg :: X86.X86Reg -> Bool
-is_control_reg reg = case reg of
-  X86RegCr0 -> True
-  X86RegCr1 -> True
-  X86RegCr2 -> True
-  X86RegCr3 -> True
-  X86RegCr4 -> True
-  X86RegCr5 -> True
-  X86RegCr6 -> True
-  X86RegCr7 -> True
-  X86RegCr8 -> True
-  X86RegCr9 -> True
-  X86RegCr10 -> True
-  X86RegCr11 -> True
-  X86RegCr12 -> True
-  X86RegCr13 -> True
-  X86RegCr14 -> True
-  X86RegCr15 -> True
 
 -- Make list of operations in the IR that has the same semantics as the X86 mov instruction
 
@@ -382,4 +419,5 @@ store_node operand store_what =
   case operand of
     (Reg reg) -> (SetReg reg store_what)
     (Mem mem) -> Store (getLeaAst mem) store_what
-    (Imm _) -> AssertNode "store to imm, wtf"
+    _ -> error "Target of store operation is neither a register nor a memory operand."
+    

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -160,8 +160,8 @@ xor_s inst =
       SetFlag Overflow (BvNode 0 1)
     ]
 
-push ::  CsInsn -> [AstNodeType]
-push inst =
+push_s ::  CsInsn -> [AstNodeType]
+push_s inst =
   let (op1 : _) = x86operands inst
       op1ast = getOperandAst op1
   in [
@@ -169,8 +169,8 @@ push inst =
       Store (GetReg stack_register) op1ast
     ]
 
-pop ::  CsInsn -> [AstNodeType]
-pop inst =
+pop_s ::  CsInsn -> [AstNodeType]
+pop_s inst =
   --whenever the operation is a store reg or store mem depends on op1
   let
     read_exp = Read (BvaddNode (GetReg stack_register) (BvNode 4 32))

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -14,8 +14,8 @@ import           Data.Maybe
 
 -- Make operation to set the zero flag to the value that it would have after some operation
 
-zf_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType
-zf_s inst parent dst =
+zf_s :: AstNodeType -> CsX86Op -> AstNodeType
+zf_s parent dst =
   let bv_size = (size dst) * 8 in
     IteNode
       (EqualNode (ExtractNode (bv_size - 1) 0 parent) (BvNode 0 bv_size))
@@ -24,8 +24,8 @@ zf_s inst parent dst =
 
 -- Make operation to set the overflow flag to the value that it would have after an add operation
 
-of_add_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
-of_add_s inst parent dst op1ast op2ast =
+of_add_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+of_add_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
       (BvandNode
@@ -34,8 +34,8 @@ of_add_s inst parent dst op1ast op2ast =
 
 -- Make operation to set the carry flag to the value that it would have after an add operation
 
-cf_add_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
-cf_add_s inst parent dst op1ast op2ast =
+cf_add_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+cf_add_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
       (BvxorNode (BvandNode op1ast op2ast)
@@ -46,8 +46,8 @@ cf_add_s inst parent dst op1ast op2ast =
 
 -- Make operation to set the adjust flag to the value that it would have after some operation
 
-af_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
-af_s inst parent dst op1ast op2ast =
+af_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+af_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     IteNode
       (EqualNode
@@ -64,8 +64,8 @@ byte_size_bit = 8
 
 -- Make operation to set the parity flag to the value that it would have after some operation
 
-pf_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType
-pf_s inst parent dst =
+pf_s :: AstNodeType -> CsX86Op -> AstNodeType
+pf_s parent dst =
   let loop counter =
         (if counter == byte_size_bit
           then (BvNode 1 1)
@@ -79,8 +79,8 @@ pf_s inst parent dst =
 
 -- Make operation to set the sign flag to the value that it would have after some operation
 
-sf_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType
-sf_s inst parent dst =
+sf_s :: AstNodeType -> CsX86Op -> AstNodeType
+sf_s parent dst =
   let bv_size = (size dst) * 8 in
     (ExtractNode (bv_size - 1) (bv_size - 1) parent)
 
@@ -94,18 +94,18 @@ add_s inst =
       add_node = (BvaddNode op1ast op2ast)
   in [
       store_node (value op1) add_node,
-      SetFlag Adjust (af_s inst add_node op1 op1ast op1ast),
-      SetFlag Parity (pf_s inst add_node op1),
-      SetFlag Sign (sf_s inst add_node op1),
-      SetFlag Zero (zf_s inst add_node op1),
-      SetFlag Carry (cf_add_s inst add_node op1 op1ast op1ast),
-      SetFlag Overflow (of_add_s inst add_node op1 op1ast op1ast)
+      SetFlag Adjust (af_s add_node op1 op1ast op1ast),
+      SetFlag Parity (pf_s add_node op1),
+      SetFlag Sign (sf_s add_node op1),
+      SetFlag Zero (zf_s add_node op1),
+      SetFlag Carry (cf_add_s add_node op1 op1ast op1ast),
+      SetFlag Overflow (of_add_s add_node op1 op1ast op1ast)
     ]
 
 -- Make operation to set the carry flag to the value that it would have after an sub operation
 
-cf_sub_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
-cf_sub_s inst parent dst op1ast op2ast =
+cf_sub_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+cf_sub_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
       (BvxorNode
@@ -116,8 +116,8 @@ cf_sub_s inst parent dst op1ast op2ast =
 
 -- Make operation to set the overflow flag to the value that it would have after an sub operation
 
-of_sub_s :: CsInsn -> AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
-of_sub_s inst parent dst op1ast op2ast =
+of_sub_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+of_sub_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
       (BvandNode
@@ -134,12 +134,12 @@ sub_s inst =
       sub_node = (BvsubNode op1ast op2ast)
   in [
       store_node (value op1) sub_node,
-      SetFlag Adjust (af_s inst sub_node op1 op1ast op1ast),
-      SetFlag Parity (pf_s inst sub_node op1),
-      SetFlag Sign (sf_s inst sub_node op1),
-      SetFlag Zero (zf_s inst sub_node op1),
-      SetFlag Carry (cf_sub_s inst sub_node op1 op1ast op1ast),
-      SetFlag Overflow (of_sub_s inst sub_node op1 op1ast op1ast)
+      SetFlag Adjust (af_s sub_node op1 op1ast op1ast),
+      SetFlag Parity (pf_s sub_node op1),
+      SetFlag Sign (sf_s sub_node op1),
+      SetFlag Zero (zf_s sub_node op1),
+      SetFlag Carry (cf_sub_s sub_node op1 op1ast op1ast),
+      SetFlag Overflow (of_sub_s sub_node op1 op1ast op1ast)
     ]
 
 -- Make list of operations in the IR that has the same semantics as the X86 xor instruction
@@ -153,9 +153,9 @@ xor_s inst =
   in [
       store_node (value op1) xor_node,
       SetFlag Adjust UndefinedNode,
-      SetFlag Parity (pf_s inst xor_node op1),
-      SetFlag Sign (sf_s inst xor_node op1),
-      SetFlag Zero (zf_s inst xor_node op1),
+      SetFlag Parity (pf_s xor_node op1),
+      SetFlag Sign (sf_s xor_node op1),
+      SetFlag Zero (zf_s xor_node op1),
       SetFlag Carry (BvNode 0 1),
       SetFlag Overflow (BvNode 0 1)
     ]

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -9,12 +9,13 @@ import           Hapstone.Internal.X86      as X86
 import           Util
 import           AstContext
 import           Data.Maybe
+import           Data.Word
 
 --ll, ml, hl
 
 -- Make operation to set the zero flag to the value that it would have after some operation
 
-zf_s :: AstNodeType -> CsX86Op -> AstNodeType
+zf_s :: AstNode -> CsX86Op -> AstNode
 zf_s parent dst =
   let bv_size = (size dst) * 8 in
     IteNode
@@ -24,7 +25,7 @@ zf_s parent dst =
 
 -- Make operation to set the overflow flag to the value that it would have after an add operation
 
-of_add_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+of_add_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> AstNode
 of_add_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
@@ -34,7 +35,7 @@ of_add_s parent dst op1ast op2ast =
 
 -- Make operation to set the carry flag to the value that it would have after an add operation
 
-cf_add_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+cf_add_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> AstNode
 cf_add_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
@@ -46,7 +47,7 @@ cf_add_s parent dst op1ast op2ast =
 
 -- Make operation to set the adjust flag to the value that it would have after some operation
 
-af_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+af_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> AstNode
 af_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     IteNode
@@ -64,7 +65,7 @@ byte_size_bit = 8
 
 -- Make operation to set the parity flag to the value that it would have after some operation
 
-pf_s :: AstNodeType -> CsX86Op -> AstNodeType
+pf_s :: AstNode -> CsX86Op -> AstNode
 pf_s parent dst =
   let loop counter =
         (if counter == byte_size_bit
@@ -79,14 +80,14 @@ pf_s parent dst =
 
 -- Make operation to set the sign flag to the value that it would have after some operation
 
-sf_s :: AstNodeType -> CsX86Op -> AstNodeType
+sf_s :: AstNode -> CsX86Op -> AstNode
 sf_s parent dst =
   let bv_size = (size dst) * 8 in
     (ExtractNode (bv_size - 1) (bv_size - 1) parent)
 
 -- Make list of operations in the IR that has the same semantics as the X86 add instruction
 
-add_s :: CsInsn -> [AstNodeType]
+add_s :: CsInsn -> [AstNode]
 add_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
@@ -104,7 +105,7 @@ add_s inst =
 
 -- Make operation to set the carry flag to the value that it would have after an sub operation
 
-cf_sub_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+cf_sub_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> AstNode
 cf_sub_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
@@ -116,7 +117,7 @@ cf_sub_s parent dst op1ast op2ast =
 
 -- Make operation to set the overflow flag to the value that it would have after an sub operation
 
-of_sub_s :: AstNodeType -> CsX86Op -> AstNodeType -> AstNodeType -> AstNodeType
+of_sub_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> AstNode
 of_sub_s parent dst op1ast op2ast =
   let bv_size = (size dst) * 8 in
     ExtractNode (bv_size - 1) (bv_size - 1)
@@ -126,7 +127,7 @@ of_sub_s parent dst op1ast op2ast =
 
 -- Make list of operations in the IR that has the same semantics as the X86 sub instruction
 
-sub_s :: CsInsn -> [AstNodeType]
+sub_s :: CsInsn -> [AstNode]
 sub_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
@@ -144,7 +145,7 @@ sub_s inst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 xor instruction
 
-xor_s :: CsInsn -> [AstNodeType]
+xor_s :: CsInsn -> [AstNode]
 xor_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
@@ -160,17 +161,20 @@ xor_s inst =
       SetFlag Overflow (BvNode 0 1)
     ]
 
-push_s :: [CsMode] -> CsInsn -> [AstNodeType]
+push_s :: [CsMode] -> CsInsn -> [AstNode]
 push_s modes inst =
   let (op1 : _) = x86operands inst
-      op1ast = getOperandAst op1
       sp = (stack_reg modes)
+      op1ast = getOperandAst op1
+      op_size = case (value op1) of
+        (Imm _) -> arch_size modes
+        _ -> size op1
   in [
-      SetReg sp (BvsubNode (GetReg sp) (BvNode 4 32)),
+      SetReg sp (BvsubNode (GetReg sp) (BvNode (fromInteger (toInteger op_size)) ((arch_size modes) * 8))),
       Store (GetReg sp) op1ast
     ]
 
-pop_s :: [CsMode] -> CsInsn -> [AstNodeType]
+pop_s :: [CsMode] -> CsInsn -> [AstNode]
 pop_s modes inst =
   --whenever the operation is a store reg or store mem depends on op1
   let
@@ -182,7 +186,7 @@ pop_s modes inst =
       store_node (get_first_opr_value inst) read_exp
     ]
 
-mov ::  CsInsn -> [AstNodeType]
+mov ::  CsInsn -> [AstNode]
 mov inst =
   let
     (op1 : op2 : _ ) = x86operands inst
@@ -214,8 +218,14 @@ stack_reg mode =
   else
     error "Processor modes underspecified."
 
+arch_size :: [CsMode] -> Word8
+arch_size mode =
+  if elem CsMode32 mode then 4
+  else if elem CsMode32 mode then 8
+  else error "Processor modes underspecified."
+
 --byte size is ignored
-store_node :: CsX86OpValue -> AstNodeType -> AstNodeType
+store_node :: CsX86OpValue -> AstNode -> AstNode
 store_node operand store_what =
             case operand of
               (Reg reg) -> (SetReg (X86Reg reg) store_what)

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -194,7 +194,7 @@ sf_s parent dst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 add instruction
 
-add_s :: CsInsn -> [AstNode]
+add_s :: CsInsn -> [Stmt]
 add_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
@@ -234,7 +234,7 @@ of_sub_s parent dst op1ast op2ast =
 
 -- Make list of operations in the IR that has the same semantics as the X86 sub instruction
 
-sub_s :: CsInsn -> [AstNode]
+sub_s :: CsInsn -> [Stmt]
 sub_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
@@ -252,7 +252,7 @@ sub_s inst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 xor instruction
 
-xor_s :: CsInsn -> [AstNode]
+xor_s :: CsInsn -> [Stmt]
 xor_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
@@ -270,7 +270,7 @@ xor_s inst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 and instruction
 
-and_s :: CsInsn -> [AstNode]
+and_s :: CsInsn -> [Stmt]
 and_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
@@ -288,7 +288,7 @@ and_s inst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 or instruction
 
-or_s :: CsInsn -> [AstNode]
+or_s :: CsInsn -> [Stmt]
 or_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
@@ -304,14 +304,9 @@ or_s inst =
       SetFlag Overflow (BvNode 0 1)
     ]
 
--- Convert instance of integral type to instance of some numerical type
-
-convert :: Integral a => Num b => a -> b
-convert a = (fromInteger (toInteger a))
-
 -- Make list of operations in the IR that has the same semantics as the X86 push instruction
 
-push_s :: [CsMode] -> CsInsn -> [AstNode]
+push_s :: [CsMode] -> CsInsn -> [Stmt]
 push_s modes inst =
   let (op1 : _) = x86operands inst
       sp = (get_stack_reg modes)
@@ -333,7 +328,7 @@ includeIf cond sublist = if cond then sublist else []
 
 -- Make list of operations in the IR that has the same semantics as the X86 pop instruction
 
-pop_s :: [CsMode] -> CsInsn -> [AstNode]
+pop_s :: [CsMode] -> CsInsn -> [Stmt]
 pop_s modes inst =
   let (op1 : _) = x86operands inst
       sp = get_stack_reg modes
@@ -356,7 +351,7 @@ pop_s modes inst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 mov instruction
 
-mov ::  CsInsn -> [AstNode]
+mov ::  CsInsn -> [Stmt]
 mov inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
@@ -414,10 +409,10 @@ get_arch_size modes =
   else error "Processor modes underspecified."
 
 --byte size is ignored
-store_node :: CsX86OpValue -> AstNode -> AstNode
+store_node :: CsX86OpValue -> AstNode -> Stmt
 store_node operand store_what =
   case operand of
-    (Reg reg) -> (SetReg reg store_what)
+    (Reg reg) -> SetReg reg store_what
     (Mem mem) -> Store (getLeaAst mem) store_what
     _ -> error "Target of store operation is neither a register nor a memory operand."
     


### PR DESCRIPTION
Implemented more x86 semantics: MOV, PUSH, POP, AND, and OR are now done. Split AstNode type into AstNode and Stmt because some of the constructors are evaluated and others are executed. Also started implementing AstNode evaluation.