### PR TITLE
Ir evaluation

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -48,7 +48,7 @@ flagToBit flag = case flag of
 
 -- A representation of a register as a list of indicies. Enables overlapping registers.
 
-type CompoundReg = [Int]
+type CompoundReg = (Int, Int)
 
 -- A map from X86Regs to locations in the register file
 
@@ -57,45 +57,45 @@ x86RegisterMap :: [(X86.X86Reg, CompoundReg)]
 x86RegisterMap = [
 -- 8-bit operands
 
-  (X86RegAh, [1..1]), (X86RegBh, [9..9]), (X86RegCh, [17..17]), (X86RegDh, [25..25]),
+  (X86RegAh, (1,1)), (X86RegBh, (9,9)), (X86RegCh, (17,17)), (X86RegDh, (25,25)),
 
-  (X86RegAl, [0..0]), (X86RegBl, [8..8]), (X86RegCl, [16..16]), (X86RegDl, [24..24]),
-  (X86RegDil, [32..32]), (X86RegSil, [40..40]), (X86RegBpl, [48..48]), (X86RegSpl, [56..56]),
-  (X86RegR8b, [64..64]), (X86RegR9b, [72..72]), (X86RegR10b, [80..80]), (X86RegR11b, [88..88]),
-  (X86RegR12b, [96..96]), (X86RegR13b, [104..104]), (X86RegR14b, [112..112]), (X86RegR15b, [120..120]),
+  (X86RegAl, (0,0)), (X86RegBl, (8,8)), (X86RegCl, (16,16)), (X86RegDl, (24,24)),
+  (X86RegDil, (32,32)), (X86RegSil, (40,40)), (X86RegBpl, (48,48)), (X86RegSpl, (56,56)),
+  (X86RegR8b, (64,64)), (X86RegR9b, (72,72)), (X86RegR10b, (80,80)), (X86RegR11b, (88,88)),
+  (X86RegR12b, (96,96)), (X86RegR13b, (104,104)), (X86RegR14b, (112,112)), (X86RegR15b, (120,120)),
 
 -- 16-bit operands
 
-  (X86RegAx, [0..1]), (X86RegBx, [8..9]), (X86RegCx, [16..17]), (X86RegDx, [24..25]),
-  (X86RegDi, [32..33]), (X86RegSi, [40..41]), (X86RegBp, [48..49]), (X86RegSp, [56..57]),
-  (X86RegR8w, [64..65]), (X86RegR9w, [72..73]), (X86RegR10w, [80..81]), (X86RegR11w, [88..89]),
-  (X86RegR12w, [96..97]), (X86RegR13w, [104..105]), (X86RegR14w, [112..113]), (X86RegR15w, [120..121]),
-  (X86RegIp, [184, 185]),
+  (X86RegAx, (0,1)), (X86RegBx, (8,9)), (X86RegCx, (16,17)), (X86RegDx, (24,25)),
+  (X86RegDi, (32,33)), (X86RegSi, (40,41)), (X86RegBp, (48,49)), (X86RegSp, (56,57)),
+  (X86RegR8w, (64,65)), (X86RegR9w, (72,73)), (X86RegR10w, (80,81)), (X86RegR11w, (88,89)),
+  (X86RegR12w, (96,97)), (X86RegR13w, (104,105)), (X86RegR14w, (112,113)), (X86RegR15w, (120,121)),
+  (X86RegIp, (184,185)),
 
 -- 32-bit operands
 
-  (X86RegEax, [0..3]), (X86RegEbx, [8..11]), (X86RegEcx, [16..19]), (X86RegEdx, [24..27]),
-  (X86RegEdi, [32..35]), (X86RegEsi, [40..43]), (X86RegEbp, [48..51]), (X86RegEsp, [56..59]),
-  (X86RegR8d, [64..67]), (X86RegR9d, [72..75]), (X86RegR10d, [80..83]), (X86RegR11d, [88..91]),
-  (X86RegR12d, [96..99]), (X86RegR13d, [104..107]), (X86RegR14d, [112..115]), (X86RegR15d, [120..123]),
-  (X86RegEip, [184, 187]),
+  (X86RegEax, (0,3)), (X86RegEbx, (8,11)), (X86RegEcx, (16,19)), (X86RegEdx, (24,27)),
+  (X86RegEdi, (32,35)), (X86RegEsi, (40,43)), (X86RegEbp, (48,51)), (X86RegEsp, (56,59)),
+  (X86RegR8d, (64,67)), (X86RegR9d, (72,75)), (X86RegR10d, (80,83)), (X86RegR11d, (88,91)),
+  (X86RegR12d, (96,99)), (X86RegR13d, (104,107)), (X86RegR14d, (112,115)), (X86RegR15d, (120,123)),
+  (X86RegEip, (184,187)),
 
 -- 64-bit operands
 
-  (X86RegRax, [0..7]), (X86RegRbx, [8..15]), (X86RegRcx, [16..23]), (X86RegRdx, [24..31]),
-  (X86RegRdi, [32..39]), (X86RegRsi, [40..47]), (X86RegRbp, [48..55]), (X86RegRsp, [56..63]),
-  (X86RegR8, [64..71]), (X86RegR9, [72..79]), (X86RegR10, [80..87]), (X86RegR11, [88..95]),
-  (X86RegR12, [96..103]), (X86RegR13, [104..111]), (X86RegR14, [112..119]), (X86RegR15, [120..127]),
-  (X86RegRip, [184, 191]),
+  (X86RegRax, (0,7)), (X86RegRbx, (8,15)), (X86RegRcx, (16,23)), (X86RegRdx, (24,31)),
+  (X86RegRdi, (32,39)), (X86RegRsi, (40,47)), (X86RegRbp, (48,55)), (X86RegRsp, (56,63)),
+  (X86RegR8, (64,71)), (X86RegR9, (72,79)), (X86RegR10, (80,87)), (X86RegR11, (88,95)),
+  (X86RegR12, (96,103)), (X86RegR13, (104,111)), (X86RegR14, (112,119)), (X86RegR15, (120,127)),
+  (X86RegRip, (184,191)),
 
 -- Segment Registers
 
-  (X86RegCs, [128..135]), (X86RegDs, [136..143]), (X86RegSs, [144..151]), (X86RegEs, [152..159]),
-  (X86RegFs, [160..167]), (X86RegGs, [168..175]),
+  (X86RegCs, (128,135)), (X86RegDs, (136,143)), (X86RegSs, (144,151)), (X86RegEs, (152,159)),
+  (X86RegFs, (160,167)), (X86RegGs, (168,175)),
 
 -- EFLAGS Register
 
-  (X86RegEflags, [176..183])]
+  (X86RegEflags, (176,183))]
 
 -- Convert an X86Reg to a CompoundReg
 
@@ -136,10 +136,10 @@ get_arch_size modes =
 
 getRegisterValue :: [Int] -> CompoundReg -> Int
 
-getRegisterValue regFile [] = 0
+getRegisterValue regFile (l, h) | l == h+1 = 0
 
-getRegisterValue regFile (b:bs) =
-  (regFile !! b) + (shift (getRegisterValue regFile bs) byte_size_bit)
+getRegisterValue regFile (l, h) =
+  (regFile !! l) + (shift (getRegisterValue regFile (l+1, h)) byte_size_bit)
 
 -- Replace the given index of the given list with the given value
 
@@ -153,10 +153,10 @@ replace (x:xs) idx val = x:(replace xs (idx - 1) val)
 
 update_reg_file :: [Int] -> CompoundReg -> Int -> [Int]
 
-update_reg_file regs [] _ = regs
+update_reg_file regs (l, h) _ | l == h+1 = regs
 
-update_reg_file regs (c:cs) val =
-  update_reg_file (replace regs c (val .&. ((shift 1 byte_size_bit) - 1))) cs
+update_reg_file regs (l, h) val =
+  update_reg_file (replace regs l (val .&. ((shift 1 byte_size_bit) - 1))) (l+1,h)
     (convert (shift ((convert val) :: Word) (-byte_size_bit)))
 
 -- Gets the specified bytes from memory
@@ -179,7 +179,8 @@ getRegisterValues regFile =
 
 isSubregisterOf :: CompoundReg -> CompoundReg -> Bool
 
-isSubregisterOf child parent = isSubsequenceOf child parent
+isSubregisterOf (childL, childH) (parentL, parentH) =
+  (parentL <= childL) && (parentH >= childH)
 
 -- Checks if the given register is a segment register
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -147,64 +147,64 @@ is_control_reg reg = elem reg
   X86RegCr7, X86RegCr8, X86RegCr9, X86RegCr10, X86RegCr11, X86RegCr12, X86RegCr13,
   X86RegCr14, X86RegCr15]
 
-data AstNode =
-    BvaddNode AstNode AstNode
-  | BvandNode AstNode AstNode
-  | BvashrNode AstNode AstNode
-  | BvlshrNode AstNode AstNode
-  | BvmulNode AstNode AstNode
-  | BvnandNode AstNode AstNode
-  | BvnegNode AstNode
-  | BvnorNode AstNode AstNode
-  | BvnotNode AstNode
-  | BvorNode AstNode AstNode
-  | BvrolNode AstNode AstNode
-  | BvrorNode AstNode AstNode -- can lit
-  | BvsdivNode AstNode AstNode
-  | BvsgeNode AstNode AstNode
-  | BvsgtNode AstNode AstNode
-  | BvshlNode AstNode AstNode
-  | BvsleNode AstNode AstNode
-  | BvsltNode AstNode AstNode
-  | BvsmodNode AstNode AstNode
-  | BvsremNode AstNode AstNode
-  | BvsubNode AstNode AstNode
-  | BvudivNode AstNode AstNode
-  | BvugeNode AstNode AstNode
-  | BvugtNode AstNode AstNode
-  | BvuleNode AstNode AstNode
-  | BvultNode AstNode AstNode
-  | BvuremNode AstNode AstNode
-  | BvxnorNode AstNode AstNode
-  | BvxorNode AstNode AstNode
-  | BvNode Int Int
-  | CompoundNode -- ! `[<expr1> <expr2> <expr3> ...]` node
-  | ConcatNode [AstNode]
-  | DecimalNode Int --float?
-  | DeclareNode --wtf?
-  | DistinctNode AstNode AstNode
-  | EqualNode AstNode AstNode
-  | ExtractNode Int Int AstNode -- ! `((_ extract <high> <low>) <expr>)` node
-  | ReplaceNode Int Int AstNode AstNode
-  | IffNode AstNode AstNode -- ! `(iff <expr1> <expr2>)`
-  | IteNode AstNode AstNode AstNode -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
-  | LandNode AstNode AstNode
-  | LetNode String AstNode AstNode
-  | LnotNode AstNode
-  | LorNode AstNode AstNode
-  | ReferenceNode --fix
-  | StringNode String
-  | SxNode Int AstNode
-  | VariableNode
-  | ZxNode Int AstNode
-  | UndefinedNode -- The undefined value
-  | Read Int AstNode
+data Expr =
+    BvaddExpr Expr Expr
+  | BvandExpr Expr Expr
+  | BvashrExpr Expr Expr
+  | BvlshrExpr Expr Expr
+  | BvmulExpr Expr Expr
+  | BvnandExpr Expr Expr
+  | BvnegExpr Expr
+  | BvnorExpr Expr Expr
+  | BvnotExpr Expr
+  | BvorExpr Expr Expr
+  | BvrolExpr Expr Expr
+  | BvrorExpr Expr Expr -- can lit
+  | BvsdivExpr Expr Expr
+  | BvsgeExpr Expr Expr
+  | BvsgtExpr Expr Expr
+  | BvshlExpr Expr Expr
+  | BvsleExpr Expr Expr
+  | BvsltExpr Expr Expr
+  | BvsmodExpr Expr Expr
+  | BvsremExpr Expr Expr
+  | BvsubExpr Expr Expr
+  | BvudivExpr Expr Expr
+  | BvugeExpr Expr Expr
+  | BvugtExpr Expr Expr
+  | BvuleExpr Expr Expr
+  | BvultExpr Expr Expr
+  | BvuremExpr Expr Expr
+  | BvxnorExpr Expr Expr
+  | BvxorExpr Expr Expr
+  | BvExpr Int Int
+  | CompoundExpr -- ! `[<expr1> <expr2> <expr3> ...]` node
+  | ConcatExpr [Expr]
+  | DecimalExpr Int --float?
+  | DeclareExpr --wtf?
+  | DistinctExpr Expr Expr
+  | EqualExpr Expr Expr
+  | ExtractExpr Int Int Expr -- ! `((_ extract <high> <low>) <expr>)` node
+  | ReplaceExpr Int Int Expr Expr
+  | IffExpr Expr Expr -- ! `(iff <expr1> <expr2>)`
+  | IteExpr Expr Expr Expr -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
+  | LandExpr Expr Expr
+  | LetExpr String Expr Expr
+  | LnotExpr Expr
+  | LorExpr Expr Expr
+  | ReferenceExpr --fix
+  | StringExpr String
+  | SxExpr Int Expr
+  | VariableExpr
+  | ZxExpr Int Expr
+  | UndefinedExpr -- The undefined value
+  | Read Int Expr
   | GetReg CompoundReg
   deriving (Eq, Show)
 
 data Stmt =
-    Store Int AstNode AstNode
-  | Branch AstNode AstNode
-  | SetReg CompoundReg AstNode
+    Store Int Expr Expr
+  | Branch Expr Expr
+  | SetReg CompoundReg Expr
   deriving (Eq, Show)
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -5,6 +5,7 @@ import Data.List
 import Hapstone.Internal.X86 as X86
 import Hapstone.Internal.Capstone as Capstone
 import Data.Bits
+import Util
 
 byte_size_bit :: Num a => a
 byte_size_bit = 8
@@ -138,7 +139,7 @@ getRegisterValue :: [Int] -> CompoundReg -> Int
 getRegisterValue regFile [] = 0
 
 getRegisterValue regFile (b:bs) =
-  (regFile !! b) + (2 ^ word_size_bit) * (getRegisterValue regFile bs)
+  (regFile !! b) + (shift (getRegisterValue regFile bs) byte_size_bit)
 
 -- Replace the given index of the given list with the given value
 
@@ -155,7 +156,8 @@ update_reg_file :: [Int] -> CompoundReg -> Int -> [Int]
 update_reg_file regs [] _ = regs
 
 update_reg_file regs (c:cs) val =
-  update_reg_file (replace regs c (val .&. ((2 ^ byte_size_bit) - 1))) cs (shift val (-byte_size_bit))
+  update_reg_file (replace regs c (val .&. ((shift 1 byte_size_bit) - 1))) cs
+    (convert (shift ((convert val) :: Word) (-byte_size_bit)))
 
 -- Gets the specified bytes from memory
 
@@ -166,7 +168,7 @@ getMemoryValue _ [] = 0
 getMemoryValue mem (b:bs) =
   case lookup b mem of
     Nothing -> error "Read attempted on uninitialized memory."
-    Just x -> x + (2 ^ word_size_bit) * (getMemoryValue mem bs)
+    Just x -> x + (shift (getMemoryValue mem bs) byte_size_bit)
 
 -- Get the register values from the register file
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -25,27 +25,6 @@ data X86Flag =
   | X86FlagDf | X86FlagOf | X86FlagIopl | X86FlagNt | X86FlagRf | X86FlagVm | X86FlagAc
   | X86FlagVif | X86FlagVip | X86FlagId deriving (Eq, Show)
 
-flagToBit :: X86Flag -> (Int, Int)
-
-flagToBit flag = case flag of
-  X86FlagCf -> (0,0)
-  X86FlagPf -> (2,2)
-  X86FlagAf -> (4,4)
-  X86FlagZf -> (6,6)
-  X86FlagSf -> (7,7)
-  X86FlagTf -> (8,8)
-  X86FlagIf -> (9,9)
-  X86FlagDf -> (10,10)
-  X86FlagOf -> (11,11)
-  X86FlagIopl -> (12,13)
-  X86FlagNt -> (14,14)
-  X86FlagRf -> (16,16)
-  X86FlagVm -> (17,17)
-  X86FlagAc -> (18,18)
-  X86FlagVif -> (19,19)
-  X86FlagVip -> (20,20)
-  X86FlagId -> (21,21)
-
 -- A representation of a register as a list of indicies. Enables overlapping registers.
 
 type CompoundReg = (Int, Int)
@@ -57,68 +36,89 @@ x86RegisterMap :: [(X86.X86Reg, CompoundReg)]
 x86RegisterMap = [
 -- 8-bit operands
 
-  (X86RegAh, (1,1)), (X86RegBh, (9,9)), (X86RegCh, (17,17)), (X86RegDh, (25,25)),
+  (X86RegAh, b(1,1)), (X86RegBh, b(9,9)), (X86RegCh, b(17,17)), (X86RegDh, b(25,25)),
 
-  (X86RegAl, (0,0)), (X86RegBl, (8,8)), (X86RegCl, (16,16)), (X86RegDl, (24,24)),
-  (X86RegDil, (32,32)), (X86RegSil, (40,40)), (X86RegBpl, (48,48)), (X86RegSpl, (56,56)),
-  (X86RegR8b, (64,64)), (X86RegR9b, (72,72)), (X86RegR10b, (80,80)), (X86RegR11b, (88,88)),
-  (X86RegR12b, (96,96)), (X86RegR13b, (104,104)), (X86RegR14b, (112,112)), (X86RegR15b, (120,120)),
+  (X86RegAl, b(0,0)), (X86RegBl, b(8,8)), (X86RegCl, b(16,16)), (X86RegDl, b(24,24)),
+  (X86RegDil, b(32,32)), (X86RegSil, b(40,40)), (X86RegBpl, b(48,48)), (X86RegSpl, b(56,56)),
+  (X86RegR8b, b(64,64)), (X86RegR9b, b(72,72)), (X86RegR10b, b(80,80)), (X86RegR11b, b(88,88)),
+  (X86RegR12b, b(96,96)), (X86RegR13b, b(104,104)), (X86RegR14b, b(112,112)), (X86RegR15b, b(120,120)),
 
 -- 16-bit operands
 
-  (X86RegAx, (0,1)), (X86RegBx, (8,9)), (X86RegCx, (16,17)), (X86RegDx, (24,25)),
-  (X86RegDi, (32,33)), (X86RegSi, (40,41)), (X86RegBp, (48,49)), (X86RegSp, (56,57)),
-  (X86RegR8w, (64,65)), (X86RegR9w, (72,73)), (X86RegR10w, (80,81)), (X86RegR11w, (88,89)),
-  (X86RegR12w, (96,97)), (X86RegR13w, (104,105)), (X86RegR14w, (112,113)), (X86RegR15w, (120,121)),
-  (X86RegIp, (184,185)),
+  (X86RegAx, b(0,1)), (X86RegBx, b(8,9)), (X86RegCx, b(16,17)), (X86RegDx, b(24,25)),
+  (X86RegDi, b(32,33)), (X86RegSi, b(40,41)), (X86RegBp, b(48,49)), (X86RegSp, b(56,57)),
+  (X86RegR8w, b(64,65)), (X86RegR9w, b(72,73)), (X86RegR10w, b(80,81)), (X86RegR11w, b(88,89)),
+  (X86RegR12w, b(96,97)), (X86RegR13w, b(104,105)), (X86RegR14w, b(112,113)), (X86RegR15w, b(120,121)),
+  (X86RegIp, b(184,185)),
 
 -- 32-bit operands
 
-  (X86RegEax, (0,3)), (X86RegEbx, (8,11)), (X86RegEcx, (16,19)), (X86RegEdx, (24,27)),
-  (X86RegEdi, (32,35)), (X86RegEsi, (40,43)), (X86RegEbp, (48,51)), (X86RegEsp, (56,59)),
-  (X86RegR8d, (64,67)), (X86RegR9d, (72,75)), (X86RegR10d, (80,83)), (X86RegR11d, (88,91)),
-  (X86RegR12d, (96,99)), (X86RegR13d, (104,107)), (X86RegR14d, (112,115)), (X86RegR15d, (120,123)),
-  (X86RegEip, (184,187)),
+  (X86RegEax, b(0,3)), (X86RegEbx, b(8,11)), (X86RegEcx, b(16,19)), (X86RegEdx, b(24,27)),
+  (X86RegEdi, b(32,35)), (X86RegEsi, b(40,43)), (X86RegEbp, b(48,51)), (X86RegEsp, b(56,59)),
+  (X86RegR8d, b(64,67)), (X86RegR9d, b(72,75)), (X86RegR10d, b(80,83)), (X86RegR11d, b(88,91)),
+  (X86RegR12d, b(96,99)), (X86RegR13d, b(104,107)), (X86RegR14d, b(112,115)), (X86RegR15d, b(120,123)),
+  (X86RegEip, b(184,187)),
 
 -- 64-bit operands
 
-  (X86RegRax, (0,7)), (X86RegRbx, (8,15)), (X86RegRcx, (16,23)), (X86RegRdx, (24,31)),
-  (X86RegRdi, (32,39)), (X86RegRsi, (40,47)), (X86RegRbp, (48,55)), (X86RegRsp, (56,63)),
-  (X86RegR8, (64,71)), (X86RegR9, (72,79)), (X86RegR10, (80,87)), (X86RegR11, (88,95)),
-  (X86RegR12, (96,103)), (X86RegR13, (104,111)), (X86RegR14, (112,119)), (X86RegR15, (120,127)),
-  (X86RegRip, (184,191)),
+  (X86RegRax, b(0,7)), (X86RegRbx, b(8,15)), (X86RegRcx, b(16,23)), (X86RegRdx, b(24,31)),
+  (X86RegRdi, b(32,39)), (X86RegRsi, b(40,47)), (X86RegRbp, b(48,55)), (X86RegRsp, b(56,63)),
+  (X86RegR8, b(64,71)), (X86RegR9, b(72,79)), (X86RegR10, b(80,87)), (X86RegR11, b(88,95)),
+  (X86RegR12, b(96,103)), (X86RegR13, b(104,111)), (X86RegR14, b(112,119)), (X86RegR15, b(120,127)),
+  (X86RegRip, b(184,191)),
 
 -- Segment Registers
 
-  (X86RegCs, (128,135)), (X86RegDs, (136,143)), (X86RegSs, (144,151)), (X86RegEs, (152,159)),
-  (X86RegFs, (160,167)), (X86RegGs, (168,175)),
+  (X86RegCs, b(128,135)), (X86RegDs, b(136,143)), (X86RegSs, b(144,151)), (X86RegEs, b(152,159)),
+  (X86RegFs, b(160,167)), (X86RegGs, b(168,175))
 
 -- EFLAGS Register
 
-  (X86RegEflags, (176,183))]
+  {-,(X86RegEflags, b(176,183))-}] where b(l,h) = (l*byte_size_bit,h*byte_size_bit)
 
 -- Convert an X86Reg to a CompoundReg
 
-compoundReg :: X86.X86Reg -> CompoundReg
+fromX86Reg :: X86.X86Reg -> CompoundReg
 
-compoundReg reg = case lookup reg x86RegisterMap of
+fromX86Reg reg = case lookup reg x86RegisterMap of
   Nothing -> error "X86 register could not be found in map."
+  Just x -> x
+
+-- A map from X86Flags to locations in the register file
+
+x86FlagMap :: [(X86Flag, CompoundReg)]
+
+x86FlagMap = [(X86FlagCf, c(176,0,0)), (X86FlagPf, c(176,2,2)),
+  (X86FlagAf, c(176,4,4)), (X86FlagZf, c(176,6,6)), (X86FlagSf, c(176,7,7)),
+  (X86FlagTf, c(176,8,8)), (X86FlagIf, c(176,9,9)), (X86FlagDf, c(176,10,10)),
+  (X86FlagOf, c(176,11,11)), (X86FlagIopl, c(176,12,13)), (X86FlagNt, c(176,14,14)),
+  (X86FlagRf, c(176,16,16)), (X86FlagVm, c(176,17,17)), (X86FlagAc, c(176,18,18)),
+  (X86FlagVif, c(176,19,19)), (X86FlagVip, c(176,20,20)), (X86FlagId, c(176,21,21))]
+  
+  where c(b,l,h) = (b*byte_size_bit+l,b*byte_size_bit+h)
+
+-- Convert an X86Reg to a CompoundReg
+
+fromX86Flag :: X86Flag -> CompoundReg
+
+fromX86Flag reg = case lookup reg x86FlagMap of
+  Nothing -> error "X86 flag could not be found in map."
   Just x -> x
 
 -- Gets the size of the given register in bits
 
 getRegSize :: CompoundReg -> Int
 
-getRegSize (l, h) = (h - l) * 8
+getRegSize (l, h) = h - l
 
 -- Gets the stack register for the given processor mode
 
 get_stack_reg :: [CsMode] -> CompoundReg
 
 get_stack_reg modes =
-  if elem CsMode16 modes then compoundReg X86RegSp
-  else if elem CsMode32 modes then compoundReg X86RegEsp
-  else if elem CsMode64 modes then compoundReg X86RegRsp
+  if elem CsMode16 modes then fromX86Reg X86RegSp
+  else if elem CsMode32 modes then fromX86Reg X86RegEsp
+  else if elem CsMode64 modes then fromX86Reg X86RegRsp
   else error "Processor modes underspecified."
 
 -- Gets the instruction pointer for the given processor mode
@@ -126,9 +126,9 @@ get_stack_reg modes =
 get_insn_ptr :: [CsMode] -> CompoundReg
 
 get_insn_ptr modes =
-  if elem CsMode16 modes then compoundReg X86RegIp
-  else if elem CsMode32 modes then compoundReg X86RegEip
-  else if elem CsMode64 modes then compoundReg X86RegRip
+  if elem CsMode16 modes then fromX86Reg X86RegIp
+  else if elem CsMode32 modes then fromX86Reg X86RegEip
+  else if elem CsMode64 modes then fromX86Reg X86RegRip
   else error "Processor modes underspecified."
 
 -- Gets the architecture size for the given processor mode
@@ -141,14 +141,32 @@ get_arch_size modes =
   else if elem CsMode64 modes then 8
   else error "Processor modes underspecified."
 
+-- Get the given bit of the integer
+
+getBit :: Int -> Int -> Int
+
+getBit value bit = if testBit value bit then 1 else 0
+
 -- Gets the value of the specified compound register from the register file
 
 getRegisterValue :: [Int] -> CompoundReg -> Int
 
-getRegisterValue regFile (l, h) | l == h+1 = 0
+getRegisterValue regFile (l, h) | l > h = 0
+
+-- If the register's bits are multiples of byte_size_bit, access them using a list index
+
+getRegisterValue regFile (l, h) | (mod l byte_size_bit == 0) && (mod h byte_size_bit == 0) =
+  let l_byte = div l byte_size_bit
+      upper_bytes = getRegisterValue regFile (l+byte_size_bit, h)
+  in (regFile !! l_byte) + shift upper_bytes byte_size_bit
+
+-- Otherwise get the register value from the register file one bit at a time
 
 getRegisterValue regFile (l, h) =
-  (regFile !! l) + (shift (getRegisterValue regFile (l+1, h)) byte_size_bit)
+  let l_byte = div l byte_size_bit
+      l_bit = mod l byte_size_bit
+      upper_bits = getRegisterValue regFile (l+1, h)
+  in getBit (regFile !! l_byte) l_bit + shift upper_bits 1
 
 -- Replace the given index of the given list with the given value
 
@@ -158,15 +176,36 @@ replace (_:xs) 0 val = val:xs
 
 replace (x:xs) idx val = x:(replace xs (idx - 1) val)
 
+-- Set the given bit of the integer to the given value
+
+assignBit :: Int -> Int -> Int -> Int
+
+assignBit value bit state =
+  (value .&. (complement (shift 1 bit))) .|. (shift state bit)
+
 -- Updates the given register file by putting the given value in the given register
 
 update_reg_file :: [Int] -> CompoundReg -> Int -> [Int]
 
-update_reg_file regs (l, h) _ | l == h+1 = regs
+update_reg_file regs (l, h) _ | l > h = regs
+
+-- If the register's bits are multiples of byte_size_bit, access them using a list index
+
+update_reg_file regs (l, h) val | (mod l byte_size_bit == 0) && (mod h byte_size_bit == 0) =
+  let l_byte = div l byte_size_bit
+      val_byte0 = val .&. (bit byte_size_bit - 1)
+      upper_bytes = convert (shift ((convert val) :: Word) (-byte_size_bit))
+  in update_reg_file (replace regs l_byte val_byte0) (l+byte_size_bit,h) upper_bytes
+
+-- Otherwise put the given value into the register file one bit at a time
 
 update_reg_file regs (l, h) val =
-  update_reg_file (replace regs l (val .&. ((shift 1 byte_size_bit) - 1))) (l+1,h)
-    (convert (shift ((convert val) :: Word) (-byte_size_bit)))
+  let l_byte = div l byte_size_bit
+      l_rounded = l_byte * byte_size_bit
+      effective_reg = (l_rounded, l_rounded + byte_size_bit)
+      current_val = getRegisterValue regs effective_reg
+      new_val = assignBit current_val (mod l byte_size_bit) (val .&. 1)
+  in update_reg_file (replace regs l_byte new_val) (l+1,h) (shift val (-1))
 
 -- Gets the specified bytes from memory
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -105,9 +105,16 @@ compoundReg reg = case lookup reg x86RegisterMap of
   Nothing -> error "X86 register could not be found in map."
   Just x -> x
 
+-- Gets the size of the given register in bits
+
+getRegSize :: CompoundReg -> Int
+
+getRegSize (l, h) = (h - l) * 8
+
 -- Gets the stack register for the given processor mode
 
 get_stack_reg :: [CsMode] -> CompoundReg
+
 get_stack_reg modes =
   if elem CsMode16 modes then compoundReg X86RegSp
   else if elem CsMode32 modes then compoundReg X86RegEsp
@@ -117,6 +124,7 @@ get_stack_reg modes =
 -- Gets the instruction pointer for the given processor mode
 
 get_insn_ptr :: [CsMode] -> CompoundReg
+
 get_insn_ptr modes =
   if elem CsMode16 modes then compoundReg X86RegIp
   else if elem CsMode32 modes then compoundReg X86RegEip
@@ -126,6 +134,7 @@ get_insn_ptr modes =
 -- Gets the architecture size for the given processor mode
 
 get_arch_size :: [CsMode] -> Int
+
 get_arch_size modes =
   if elem CsMode16 modes then 2
   else if elem CsMode32 modes then 4

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -204,7 +204,7 @@ data AstNode =
 
 data Stmt =
     Store Word8 AstNode AstNode
-  | JccNode AstNode Int
+  | Branch AstNode AstNode
   | SetReg CompoundReg AstNode
   deriving (Eq, Show)
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -45,8 +45,6 @@ flagToBit flag = case flag of
   X86FlagVip -> (20,20)
   X86FlagId -> (21,21)
 
-type Label = (Int, Int)
-
 -- A representation of a register as a list of indicies. Enables overlapping registers.
 
 type CompoundReg = [Int]
@@ -106,6 +104,8 @@ compoundReg reg = case lookup reg x86RegisterMap of
   Nothing -> error "X86 register could not be found in map."
   Just x -> x
 
+-- Gets the stack register for the given processor mode
+
 get_stack_reg :: [CsMode] -> CompoundReg
 get_stack_reg modes =
   if elem CsMode16 modes then compoundReg X86RegSp
@@ -113,12 +113,16 @@ get_stack_reg modes =
   else if elem CsMode64 modes then compoundReg X86RegRsp
   else error "Processor modes underspecified."
 
+-- Gets the instruction pointer for the given processor mode
+
 get_insn_ptr :: [CsMode] -> CompoundReg
 get_insn_ptr modes =
   if elem CsMode16 modes then compoundReg X86RegIp
   else if elem CsMode32 modes then compoundReg X86RegEip
   else if elem CsMode64 modes then compoundReg X86RegRip
   else error "Processor modes underspecified."
+
+-- Gets the architecture size for the given processor mode
 
 get_arch_size :: [CsMode] -> Int
 get_arch_size modes =
@@ -143,6 +147,10 @@ replace :: [a] -> Int -> a -> [a]
 replace (_:xs) 0 val = val:xs
 
 replace (x:xs) idx val = x:(replace xs (idx - 1) val)
+
+-- Updates the given register file by putting the given value in the given register
+
+update_reg_file :: [Int] -> CompoundReg -> Int -> [Int]
 
 update_reg_file regs [] _ = regs
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -43,6 +43,8 @@ flagToBit flag = case flag of
   X86FlagVip -> (20,20)
   X86FlagId -> (21,21)
 
+type Label = (Word64, Int)
+
 -- A representation of a register as a list of indicies. Enables overlapping registers.
 
 type CompoundReg = [Int]
@@ -202,6 +204,7 @@ data AstNode =
 
 data Stmt =
     Store Word8 AstNode AstNode
+  | JccNode AstNode Int
   | SetReg CompoundReg AstNode
   deriving (Eq, Show)
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -43,7 +43,7 @@ flagToBit flag = case flag of
   X86FlagVip -> (20,20)
   X86FlagId -> (21,21)
 
-type Label = (Word64, Int)
+type Label = (Int, Int)
 
 -- A representation of a register as a list of indicies. Enables overlapping registers.
 
@@ -177,15 +177,15 @@ data AstNode =
   | BvuremNode AstNode AstNode
   | BvxnorNode AstNode AstNode
   | BvxorNode AstNode AstNode
-  | BvNode Word64 Word8
+  | BvNode Int Int
   | CompoundNode -- ! `[<expr1> <expr2> <expr3> ...]` node
   | ConcatNode [AstNode]
   | DecimalNode Int --float?
   | DeclareNode --wtf?
   | DistinctNode AstNode AstNode
   | EqualNode AstNode AstNode
-  | ExtractNode Word8 Word8 AstNode -- ! `((_ extract <high> <low>) <expr>)` node
-  | ReplaceNode Word8 Word8 AstNode AstNode
+  | ExtractNode Int Int AstNode -- ! `((_ extract <high> <low>) <expr>)` node
+  | ReplaceNode Int Int AstNode AstNode
   | IffNode AstNode AstNode -- ! `(iff <expr1> <expr2>)`
   | IteNode AstNode AstNode AstNode -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
   | LandNode AstNode AstNode
@@ -198,12 +198,12 @@ data AstNode =
   | VariableNode
   | ZxNode Int AstNode
   | UndefinedNode -- The undefined value
-  | Read Word8 AstNode
+  | Read Int AstNode
   | GetReg CompoundReg
   deriving (Eq, Show)
 
 data Stmt =
-    Store Word8 AstNode AstNode
+    Store Int AstNode AstNode
   | Branch AstNode AstNode
   | SetReg CompoundReg AstNode
   deriving (Eq, Show)

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -8,37 +8,3 @@ import Hapstone.Internal.X86      as X86
 import Data.Word
 import Util
 
--- Gets an expression for the given operand. Processor mode may be needed for computing
--- effective addresses.
-
-getOperandAst :: [CsMode] -> CsX86Op -> Expr
-
-getOperandAst modes op = case value op of
-  (Imm value) -> BvExpr (convert value) (convert (size op) * 8)
-  (Reg reg) -> GetReg (compoundReg reg)
-  (Mem mem) -> Load (convert $ size op) (getLeaAst modes mem)
-
--- Gets the specified register after it has been zero extended to the architecture size
-
-getZxRegister :: [CsMode] -> CompoundReg -> Expr
-
-getZxRegister modes reg =
-  ZxExpr (arch_size - reg_size) (GetReg reg) where
-    arch_size = get_arch_size modes
-    reg_size = getRegSize reg
-
--- Gets an expression for the memory location of the given memory operand
-
-getLeaAst :: [CsMode] -> X86OpMemStruct -> Expr
-
-getLeaAst modes mem =
-  (BvaddExpr node_disp (BvaddExpr node_base node_index)) where
-    arch_size = get_arch_size modes
-    node_base = case base mem of
-      X86RegInvalid -> (BvExpr 0 arch_size)
-      reg -> getZxRegister modes (compoundReg reg)
-    node_index = case index mem of
-      X86RegInvalid -> (BvExpr 0 arch_size)
-      reg -> BvmulExpr (getZxRegister modes (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) arch_size)
-    node_disp = BvExpr (fromIntegral $ disp' mem) arch_size
-

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -8,23 +8,37 @@ import Hapstone.Internal.X86      as X86
 import Data.Word
 import Util
 
+-- Gets an expression for the given operand. Processor mode may be needed for computing
+-- effective addresses.
+
 getOperandAst :: [CsMode] -> CsX86Op -> Expr
+
 getOperandAst modes op = case value op of
   (Imm value) -> BvExpr (convert value) (convert (size op) * 8)
   (Reg reg) -> GetReg (compoundReg reg)
   (Mem mem) -> Load (convert $ size op) (getLeaAst modes mem)
 
---getZxRegister :: CsMode -> CompoundRegister
+-- Gets the specified register after it has been zero extended to the architecture size
+
+getZxRegister :: [CsMode] -> CompoundReg -> Expr
+
+getZxRegister modes reg =
+  ZxExpr (arch_size - reg_size) (GetReg reg) where
+    arch_size = get_arch_size modes
+    reg_size = getRegSize reg
+
+-- Gets an expression for the memory location of the given memory operand
 
 getLeaAst :: [CsMode] -> X86OpMemStruct -> Expr
+
 getLeaAst modes mem =
   (BvaddExpr node_disp (BvaddExpr node_base node_index)) where
     arch_size = get_arch_size modes
     node_base = case base mem of
       X86RegInvalid -> (BvExpr 0 arch_size)
-      reg -> GetReg (compoundReg reg)
+      reg -> getZxRegister modes (compoundReg reg)
     node_index = case index mem of
       X86RegInvalid -> (BvExpr 0 arch_size)
-      reg -> BvmulExpr (GetReg (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) arch_size)
+      reg -> BvmulExpr (getZxRegister modes (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) arch_size)
     node_disp = BvExpr (fromIntegral $ disp' mem) arch_size
 

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -12,7 +12,7 @@ getOperandAst :: CsX86Op -> Expr
 getOperandAst op = case value op of
   (Imm value) -> BvExpr (convert value) (convert (size op) * 8)
   (Reg reg) -> GetReg (compoundReg reg)
-  (Mem mem) -> Read (convert $ size op) (getLeaAst mem)
+  (Mem mem) -> Load (convert $ size op) (getLeaAst mem)
 
 
 getLeaAst :: X86OpMemStruct -> Expr

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -8,21 +8,21 @@ import Hapstone.Internal.X86      as X86
 import Data.Word
 import Util
 
-getOperandAst :: CsX86Op -> AstNode
+getOperandAst :: CsX86Op -> Expr
 getOperandAst op = case value op of
-  (Imm value) -> BvNode (convert value) (convert (size op) * 8)
+  (Imm value) -> BvExpr (convert value) (convert (size op) * 8)
   (Reg reg) -> GetReg (compoundReg reg)
   (Mem mem) -> Read (convert $ size op) (getLeaAst mem)
 
 
-getLeaAst :: X86OpMemStruct -> AstNode
+getLeaAst :: X86OpMemStruct -> Expr
 getLeaAst mem =
-  (BvaddNode node_disp (BvaddNode node_base node_index) ) where
+  (BvaddExpr node_disp (BvaddExpr node_base node_index) ) where
     node_base = case base mem of
-      X86RegInvalid -> (BvNode 0 32)
+      X86RegInvalid -> (BvExpr 0 32)
       reg -> GetReg (compoundReg reg)
     node_index = case index mem of
-      X86RegInvalid -> (BvNode 0 32)
-      reg -> BvmulNode (GetReg (compoundReg reg)) (BvNode (fromIntegral $ scale mem) 32)
-    node_disp = BvNode (fromIntegral $ disp' mem) 32
+      X86RegInvalid -> (BvExpr 0 32)
+      reg -> BvmulExpr (GetReg (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) 32)
+    node_disp = BvExpr (fromIntegral $ disp' mem) 32
 

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -8,21 +8,23 @@ import Hapstone.Internal.X86      as X86
 import Data.Word
 import Util
 
-getOperandAst :: CsX86Op -> Expr
-getOperandAst op = case value op of
+getOperandAst :: [CsMode] -> CsX86Op -> Expr
+getOperandAst modes op = case value op of
   (Imm value) -> BvExpr (convert value) (convert (size op) * 8)
   (Reg reg) -> GetReg (compoundReg reg)
-  (Mem mem) -> Load (convert $ size op) (getLeaAst mem)
+  (Mem mem) -> Load (convert $ size op) (getLeaAst modes mem)
 
+--getZxRegister :: CsMode -> CompoundRegister
 
-getLeaAst :: X86OpMemStruct -> Expr
-getLeaAst mem =
-  (BvaddExpr node_disp (BvaddExpr node_base node_index) ) where
+getLeaAst :: [CsMode] -> X86OpMemStruct -> Expr
+getLeaAst modes mem =
+  (BvaddExpr node_disp (BvaddExpr node_base node_index)) where
+    arch_size = get_arch_size modes
     node_base = case base mem of
-      X86RegInvalid -> (BvExpr 0 32)
+      X86RegInvalid -> (BvExpr 0 arch_size)
       reg -> GetReg (compoundReg reg)
     node_index = case index mem of
-      X86RegInvalid -> (BvExpr 0 32)
-      reg -> BvmulExpr (GetReg (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) 32)
-    node_disp = BvExpr (fromIntegral $ disp' mem) 32
+      X86RegInvalid -> (BvExpr 0 arch_size)
+      reg -> BvmulExpr (GetReg (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) arch_size)
+    node_disp = BvExpr (fromIntegral $ disp' mem) arch_size
 

--- a/src/AstContext.hs
+++ b/src/AstContext.hs
@@ -2,26 +2,27 @@ module AstContext where
 
 import Ast
 
-import           Hapstone.Capstone
-import           Hapstone.Internal.Capstone as Capstone
-import           Hapstone.Internal.X86      as X86
-import           Data.Word
+import Hapstone.Capstone
+import Hapstone.Internal.Capstone as Capstone
+import Hapstone.Internal.X86      as X86
+import Data.Word
+import Util
 
 getOperandAst :: CsX86Op -> AstNode
 getOperandAst op = case value op of
-  (Imm value) -> BvNode value ((size op) * 8)
+  (Imm value) -> BvNode (convert value) (convert (size op) * 8)
   (Reg reg) -> GetReg (compoundReg reg)
-  (Mem mem) -> Read (size op) (getLeaAst mem)
+  (Mem mem) -> Read (convert $ size op) (getLeaAst mem)
 
 
 getLeaAst :: X86OpMemStruct -> AstNode
 getLeaAst mem =
-    (BvaddNode node_disp (BvaddNode node_base node_index) ) where
-        node_base = case base mem of
-            X86RegInvalid -> (BvNode 0 32)
-            reg -> GetReg (compoundReg reg)
-        node_index = case index mem of
-            X86RegInvalid -> (BvNode 0 32)
-            reg ->
-              BvmulNode (GetReg (compoundReg reg)) (BvNode (fromIntegral $ scale mem) 32)
-        node_disp = BvNode (fromIntegral $ disp' mem) 32
+  (BvaddNode node_disp (BvaddNode node_base node_index) ) where
+    node_base = case base mem of
+      X86RegInvalid -> (BvNode 0 32)
+      reg -> GetReg (compoundReg reg)
+    node_index = case index mem of
+      X86RegInvalid -> (BvNode 0 32)
+      reg -> BvmulNode (GetReg (compoundReg reg)) (BvNode (fromIntegral $ scale mem) 32)
+    node_disp = BvNode (fromIntegral $ disp' mem) 32
+

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -85,14 +85,6 @@ assign ((c, d) : es) (a, b) | c == a = (a, b) : es
 
 assign ((c, d) : es) (a, b) | c /= a = (c, d) : assign es (a, b)
 
--- Gets the successor of the given element in the given list.
-
-after :: Eq a => [a] -> a -> a
-
-after (x:y:ys) z | x == z = y
-
-after (x:xs) y = after xs y
-
 exec :: ExecutionContext -> Stmt -> ExecutionContext
 
 -- Executes a SetReg operation by setting each byte of the register separately
@@ -117,7 +109,8 @@ exec cin (Store n dst val) =
     proc_modes = proc_modes cin
   }
 
--- Executes the statements pointed to by the instruction pointer and returns the new context
+-- Executes a group of statements pointed to by the instruction pointer and returns the
+-- new context
 
 step :: ExecutionContext -> ExecutionContext
 

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -36,38 +36,38 @@ oneBitsUpto high = (shift 1 (high + 1)) - 1
 
 oneBitsBetween high low = oneBitsUpto high - (oneBitsUpto (low - 1))
 
--- Evaluates the given node in the given context and returns the result
+-- Evaluates the given expression in the given context and returns the result
 
-eval :: ExecutionContext -> AstNode -> Int
+eval :: ExecutionContext -> Expr -> Int
 
-eval cin (BvNode a _) = a
+eval cin (BvExpr a _) = a
 
-eval cin (BvxorNode a b) = xor (eval cin a) (eval cin b)
+eval cin (BvxorExpr a b) = xor (eval cin a) (eval cin b)
 
-eval cin (BvandNode a b) = (eval cin a) .&. (eval cin b)
+eval cin (BvandExpr a b) = (eval cin a) .&. (eval cin b)
 
-eval cin (BvorNode a b) = (eval cin a) .|. (eval cin b)
+eval cin (BvorExpr a b) = (eval cin a) .|. (eval cin b)
 
-eval cin (BvnotNode a) = complement (eval cin a)
+eval cin (BvnotExpr a) = complement (eval cin a)
 
-eval cin (EqualNode a b) = if (eval cin a) == (eval cin b) then 1 else 0
+eval cin (EqualExpr a b) = if (eval cin a) == (eval cin b) then 1 else 0
 
-eval cin (BvaddNode a b) = (eval cin a) + (eval cin b)
+eval cin (BvaddExpr a b) = (eval cin a) + (eval cin b)
 
-eval cin (BvsubNode a b) = (eval cin a) - (eval cin b)
+eval cin (BvsubExpr a b) = (eval cin a) - (eval cin b)
 
-eval cin (BvlshrNode a b) = convert (shift ((convert (eval cin a)) :: Word) (-(eval cin b)))
+eval cin (BvlshrExpr a b) = convert (shift ((convert (eval cin a)) :: Word) (-(eval cin b)))
 
-eval cin (ZxNode a b) = eval cin b
+eval cin (ZxExpr a b) = eval cin b
 
-eval cin (IteNode a b c) =
+eval cin (IteExpr a b c) =
   if (eval cin a) /= 0 then eval cin b
   else eval cin c
 
-eval cin (ReplaceNode a b c d) =
+eval cin (ReplaceExpr a b c d) =
   ((eval cin c) .&. (complement (oneBitsBetween a b))) .|. shift (eval cin d) b
 
-eval cin (ExtractNode a b c) = (shift (eval cin c) (-b)) .&. ((2 ^ (a + 1 - b)) - 1)
+eval cin (ExtractExpr a b c) = (shift (eval cin c) (-b)) .&. ((2 ^ (a + 1 - b)) - 1)
 
 eval cin (GetReg bs) = getRegisterValue (reg_file cin) bs
 
@@ -157,6 +157,6 @@ iter fun 0 x = x
 iter fun n x = iter fun (n - 1) (fun x)
 
 -- by default all undefined regs are symbolic?
-symbolicEval :: ExecutionContext -> [AstNode] -> ExecutionContext
+symbolicEval :: ExecutionContext -> [Expr] -> ExecutionContext
 symbolicEval cin ast =
           cin

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -139,7 +139,7 @@ exec_aux cin (Branch cond lbl) = ExecutionContext {
     reg_file = reg_file cin,
     memory = memory cin,
     stmts = stmts cin,
-    insn_ptr = (convert (eval cin lbl), 0)
+    insn_ptr = if eval cin cond /= 0 then (convert (eval cin lbl), 0) else insn_ptr cin
   }
 
 -- Executes the statement pointed to by the instruction pointer and returns the new context

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -133,6 +133,15 @@ exec_aux cin (Store n dst val) =
     insn_ptr = after insn_ptrs (insn_ptr cin)
   }
 
+-- Executes a Branch operation by changing the instruction pointer
+
+exec_aux cin (Branch cond lbl) = ExecutionContext {
+    reg_file = reg_file cin,
+    memory = memory cin,
+    stmts = stmts cin,
+    insn_ptr = (convert (eval cin lbl), 0)
+  }
+
 -- Executes the statement pointed to by the instruction pointer and returns the new context
 
 exec :: ExecutionContext -> ExecutionContext

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -14,6 +14,7 @@ mmp modes a = (convert (address a), (case toEnum (fromIntegral (insnId a)) of
   X86InsAdd -> add_s
   X86InsMov -> mov_s
   X86InsSub -> sub_s
+  X86InsCmp -> cmp_s
   X86InsPush -> push_s
   X86InsPop -> pop_s
   X86InsXor -> xor_s

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -20,6 +20,7 @@ mmp modes a = (convert (address a), (case toEnum (fromIntegral (insnId a)) of
   X86InsAnd -> and_s
   X86InsOr -> or_s
   X86InsJmp -> jmp_s
+  X86InsJe -> je_s
   otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported.")) modes a)
 
 liftAsm :: [CsMode] -> [CsInsn] -> [(Int, [Stmt])]

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -8,32 +8,27 @@ import Hapstone.Internal.X86      as X86
 import Util
 import Data.Word
 
-labelStmts :: CsInsn -> [Stmt] -> [(Label, Stmt)]
-labelStmts insn stmts =
-  let addr = convert $ address insn
-    in zip (zip [addr,addr..] [0,1..]) stmts
-
 --x86 vs arm, etc?
-mmp :: [CsMode] -> CsInsn -> [(Label, Stmt)]
-mmp modes a = labelStmts a (case toEnum (fromIntegral (insnId a)) of
-  X86InsAdd -> add_s a
-  X86InsMov -> mov_s a
-  X86InsSub -> sub_s a
-  X86InsPush -> push_s modes a
-  X86InsPop -> pop_s modes a
-  X86InsXor -> xor_s a
-  X86InsAnd -> and_s a
-  X86InsOr -> or_s a
-  X86InsJmp -> jmp_s a
-  otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported."))
+mmp :: [CsMode] -> CsInsn -> (Int, [Stmt])
+mmp modes a = (convert (address a), (case toEnum (fromIntegral (insnId a)) of
+  X86InsAdd -> add_s
+  X86InsMov -> mov_s
+  X86InsSub -> sub_s
+  X86InsPush -> push_s
+  X86InsPop -> pop_s
+  X86InsXor -> xor_s
+  X86InsAnd -> and_s
+  X86InsOr -> or_s
+  X86InsJmp -> jmp_s
+  otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported.")) modes a)
 
-liftAsm :: [CsMode] -> [CsInsn] -> [[(Label, Stmt)]]
+liftAsm :: [CsMode] -> [CsInsn] -> [(Int, [Stmt])]
 liftAsm modes buf = map (mmp modes) buf
 
 disasm_buf :: [CsMode] -> [Word8] -> IO (Either CsErr [CsInsn])
 disasm_buf modes buffer = disasmSimpleIO $ disasm modes buffer 0
 
-liftX86toAst :: [CsMode] -> [Word8] -> IO [[(Label, Stmt)]]
+liftX86toAst :: [CsMode] -> [Word8] -> IO [(Int, [Stmt])]
 liftX86toAst modes input = do
     asm <- disasm_buf modes input
     return (case asm of

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -10,7 +10,7 @@ import Data.Word
 
 labelStmts :: CsInsn -> [Stmt] -> [(Label, Stmt)]
 labelStmts insn stmts =
-  let addr = address insn
+  let addr = convert $ address insn
     in zip (zip [addr,addr..] [0,1..]) stmts
 
 --x86 vs arm, etc?

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -8,26 +8,32 @@ import Hapstone.Internal.X86      as X86
 import Util
 import Data.Word
 
+labelStmts :: CsInsn -> [Stmt] -> [(Label, Stmt)]
+labelStmts insn stmts =
+  let addr = address insn
+    in zip (zip [addr,addr..] [0,1..]) stmts
+
 --x86 vs arm, etc?
-mmp :: [CsMode] -> CsInsn -> [Stmt]
-mmp modes a = case toEnum (fromIntegral (insnId a)) of
+mmp :: [CsMode] -> CsInsn -> [(Label, Stmt)]
+mmp modes a = labelStmts a (case toEnum (fromIntegral (insnId a)) of
   X86InsAdd -> add_s a
-  X86InsMov -> mov a
+  X86InsMov -> mov_s a
   X86InsSub -> sub_s a
   X86InsPush -> push_s modes a
   X86InsPop -> pop_s modes a
   X86InsXor -> xor_s a
   X86InsAnd -> and_s a
   X86InsOr -> or_s a
-  otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported.")
+  X86InsJmp -> jmp_s a
+  otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported."))
 
-liftAsm :: [CsMode] -> [CsInsn] -> [[Stmt]]
+liftAsm :: [CsMode] -> [CsInsn] -> [[(Label, Stmt)]]
 liftAsm modes buf = map (mmp modes) buf
 
 disasm_buf :: [CsMode] -> [Word8] -> IO (Either CsErr [CsInsn])
 disasm_buf modes buffer = disasmSimpleIO $ disasm modes buffer 0
 
-liftX86toAst :: [CsMode] -> [Word8] -> IO [[Stmt]]
+liftX86toAst :: [CsMode] -> [Word8] -> IO [[(Label, Stmt)]]
 liftX86toAst modes input = do
     asm <- disasm_buf modes input
     return (case asm of

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -22,6 +22,7 @@ mmp modes a = (convert (address a), (case toEnum (fromIntegral (insnId a)) of
   X86InsOr -> or_s
   X86InsJmp -> jmp_s
   X86InsJe -> je_s
+  X86InsLea -> lea_s
   otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported.")) modes a)
 
 liftAsm :: [CsMode] -> [CsInsn] -> [(Int, [Stmt])]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,11 +19,13 @@ main = do
               0x5B, -- pop ebx
               0x59, -- pop ecx
               0x01, 0xCB, -- add ebx,ecx
-              0xB8, 0x00, 0x00, 0x00, 0x00] -- mov eax,0x0 
+              0xB8, 0x00, 0x00, 0x00, 0x00, -- mov eax,0x0
+              -- loop:
+              0xEB, 0xFE] -- jmp loop
   let modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   case asm of
     Left _ -> print "error"
     -- Register ebx will contain 23 as it is the result of 0xa+0xd
-    Right b -> print (getRegisterValues (reg_file ((iter exec 7) (uninitializedX86Context (concat (liftAsm modes b)) (0, 0)))))
+    Right b -> print (getRegisterValues (reg_file ((iter exec 700) (uninitializedX86Context (concat (liftAsm modes b)) (0, 0)))))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,5 +19,5 @@ main = do
   case asm of
     Left _ -> print "error"
     -- Register ebx will contain 23 as it is the result of 0xa+0xd
-    Right b -> print (getRegisterValues (reg_file ((iter step 40) (uninitializedX86Context modes (liftAsm modes b)))))
+    Right b -> print (getRegisterValues (reg_file ((iter step 80) (uninitializedX86Context modes (liftAsm modes b)))))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,9 +11,11 @@ import Lifter
 
 main :: IO ()
 main = do
-  -- contents <- BS.readFile "bs/blackcipher.aes"
   print "this should be in test/"
-  let input = [0xb8, 0x0a, 0x00, 0x00, 0x00, 0x83, 0xc0, 0x0a, 0xeb, 0xfb] -- jmp loop
+  let input = [0xb8, 0x0a, 0x00, 0x00, 0x00, -- mov eax,0xa
+              -- 00000005 <loop>:
+              0x83, 0xc0, 0x0a, -- add eax,0xa
+              0xeb, 0xfb] -- jmp loop
   let modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   case asm of

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,5 +19,5 @@ main = do
   case asm of
     Left _ -> print "error"
     -- Register ebx will contain 23 as it is the result of 0xa+0xd
-    Right b -> print (getRegisterValues (reg_file ((iter exec 100) (uninitializedX86Context (concat (liftAsm modes b)) (0, 0)))))
+    Right b -> print (getRegisterValues (reg_file ((iter step 40) (uninitializedX86Context modes (liftAsm modes b)))))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,11 +18,12 @@ main = do
               0x6A, 0x0D, -- push 0xd
               0x5B, -- pop ebx
               0x59, -- pop ecx
-              0x01, 0xCB] -- add ebx,ecx 
+              0x01, 0xCB, -- add ebx,ecx
+              0xB8, 0x00, 0x00, 0x00, 0x00] -- mov eax,0x0 
   let modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   case asm of
     Left _ -> print "error"
     -- Register ebx will contain 23 as it is the result of 0xa+0xd
-    Right b -> print (getRegisterValues (reg_file (run x86Context (concat (liftAsm modes b)))))
+    Right b -> print (getRegisterValues (reg_file ((iter exec 7) (uninitializedX86Context (concat (liftAsm modes b)) (0, 0)))))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -13,19 +13,11 @@ main :: IO ()
 main = do
   -- contents <- BS.readFile "bs/blackcipher.aes"
   print "this should be in test/"
-  let input = [0xBC, 0x64, 0x00, 0x00, 0x00, -- mov esp,0x64
-              0x6A, 0x0A, -- push 0xa
-              0x6A, 0x0D, -- push 0xd
-              0x5B, -- pop ebx
-              0x59, -- pop ecx
-              0x01, 0xCB, -- add ebx,ecx
-              0xB8, 0x00, 0x00, 0x00, 0x00, -- mov eax,0x0
-              -- loop:
-              0xEB, 0xFE] -- jmp loop
+  let input = [0xb8, 0x0a, 0x00, 0x00, 0x00, 0x83, 0xc0, 0x0a, 0xeb, 0xfb] -- jmp loop
   let modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   case asm of
     Left _ -> print "error"
     -- Register ebx will contain 23 as it is the result of 0xa+0xd
-    Right b -> print (getRegisterValues (reg_file ((iter exec 700) (uninitializedX86Context (concat (liftAsm modes b)) (0, 0)))))
+    Right b -> print (getRegisterValues (reg_file ((iter exec 100) (uninitializedX86Context (concat (liftAsm modes b)) (0, 0)))))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,6 +18,6 @@ main = do
   asm <- disasm_buf modes input
   case asm of
     Left _ -> print "error"
-    -- Register ebx will contain 23 as it is the result of 0xa+0xd
+    -- Register eax will be some multiple of 10
     Right b -> print (getRegisterValues (reg_file ((iter step 80) (uninitializedX86Context modes (liftAsm modes b)))))
 

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -241,8 +241,8 @@ pop_s modes inst =
 
 -- Make list of operations in the IR that has the same semantics as the X86 mov instruction
 
-mov ::  CsInsn -> [Stmt]
-mov inst =
+mov_s ::  CsInsn -> [Stmt]
+mov_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
       src_ast = getOperandAst src_op
@@ -270,6 +270,13 @@ mov inst =
         set_flag X86FlagZf UndefinedNode,
         set_flag X86FlagCf UndefinedNode,
         set_flag X86FlagOf UndefinedNode]
+
+jmp_s :: CsInsn -> [Stmt]
+jmp_s inst =
+  let (src_op : _ ) = x86operands inst
+  in case value src_op of
+    Imm rel -> [JccNode (BvNode 1 1) (convert (address inst + convert (length (bytes inst)) + rel))]
+    _ -> error "Absolute jumps not yet implemented."
 
 getCsX86arch :: Maybe CsDetail -> Maybe CsX86
 getCsX86arch inst =

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -14,73 +14,73 @@ import Data.Word
 
 -- Make operation to set the zero flag to the value that it would have after some operation
 
-zf_s :: AstNode -> CsX86Op -> Stmt
+zf_s :: Expr -> CsX86Op -> Stmt
 zf_s parent dst =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagZf (IteNode
-      (EqualNode (ExtractNode (bv_size - 1) 0 parent) (BvNode 0 bv_size))
-      (BvNode 1 1)
-      (BvNode 0 1))
+    set_flag X86FlagZf (IteExpr
+      (EqualExpr (ExtractExpr (bv_size - 1) 0 parent) (BvExpr 0 bv_size))
+      (BvExpr 1 1)
+      (BvExpr 0 1))
 
 -- Make operation to set the overflow flag to the value that it would have after an add operation
 
-of_add_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> Stmt
+of_add_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 of_add_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagOf (ExtractNode (bv_size - 1) (bv_size - 1)
-      (BvandNode
-        (BvxorNode op1ast (BvnotNode op2ast))
-        (BvxorNode op1ast (ExtractNode (bv_size - 1) 0 parent))))
+    set_flag X86FlagOf (ExtractExpr (bv_size - 1) (bv_size - 1)
+      (BvandExpr
+        (BvxorExpr op1ast (BvnotExpr op2ast))
+        (BvxorExpr op1ast (ExtractExpr (bv_size - 1) 0 parent))))
 
 -- Make operation to set the carry flag to the value that it would have after an add operation
 
-cf_add_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> Stmt
+cf_add_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 cf_add_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagCf (ExtractNode (bv_size - 1) (bv_size - 1)
-      (BvxorNode (BvandNode op1ast op2ast)
-        (BvandNode (BvxorNode
-            (BvxorNode op1ast op2ast)
-            (ExtractNode (bv_size - 1) 0 parent))
-          (BvxorNode op1ast op2ast))))
+    set_flag X86FlagCf (ExtractExpr (bv_size - 1) (bv_size - 1)
+      (BvxorExpr (BvandExpr op1ast op2ast)
+        (BvandExpr (BvxorExpr
+            (BvxorExpr op1ast op2ast)
+            (ExtractExpr (bv_size - 1) 0 parent))
+          (BvxorExpr op1ast op2ast))))
 
 -- Make operation to set the adjust flag to the value that it would have after some operation
 
-af_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> Stmt
+af_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 af_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagAf (IteNode
-      (EqualNode
-        (BvNode 0x10 bv_size)
-        (BvandNode
-          (BvNode 0x10 bv_size)
-          (BvxorNode
-            (ExtractNode (bv_size - 1) 0 parent)
-            (BvxorNode op1ast op2ast))))
-      (BvNode 1 1)
-      (BvNode 0 1))
+    set_flag X86FlagAf (IteExpr
+      (EqualExpr
+        (BvExpr 0x10 bv_size)
+        (BvandExpr
+          (BvExpr 0x10 bv_size)
+          (BvxorExpr
+            (ExtractExpr (bv_size - 1) 0 parent)
+            (BvxorExpr op1ast op2ast))))
+      (BvExpr 1 1)
+      (BvExpr 0 1))
 
 -- Make operation to set the parity flag to the value that it would have after some operation
 
-pf_s :: AstNode -> CsX86Op -> Stmt
+pf_s :: Expr -> CsX86Op -> Stmt
 pf_s parent dst =
   let loop counter =
         (if counter == byte_size_bit
-          then (BvNode 1 1)
-          else (BvxorNode
+          then (BvExpr 1 1)
+          else (BvxorExpr
             (loop (counter + 1))
-            (ExtractNode 0 0
-              (BvlshrNode
-                (ExtractNode 7 0 parent)
-                (BvNode (fromIntegral counter) byte_size_bit))))) in
+            (ExtractExpr 0 0
+              (BvlshrExpr
+                (ExtractExpr 7 0 parent)
+                (BvExpr counter byte_size_bit))))) in
     set_flag X86FlagPf (loop 0)
 
 -- Make operation to set the sign flag to the value that it would have after some operation
 
-sf_s :: AstNode -> CsX86Op -> Stmt
+sf_s :: Expr -> CsX86Op -> Stmt
 sf_s parent dst =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagSf (ExtractNode (bv_size - 1) (bv_size - 1) parent)
+    set_flag X86FlagSf (ExtractExpr (bv_size - 1) (bv_size - 1) parent)
 
 -- Make list of operations in the IR that has the same semantics as the X86 add instruction
 
@@ -89,7 +89,7 @@ add_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
       op2ast = getOperandAst op2
-      add_node = (BvaddNode op1ast op2ast)
+      add_node = (BvaddExpr op1ast op2ast)
   in [
       store_node op1 add_node,
       af_s add_node op1 op1ast op1ast,
@@ -102,25 +102,25 @@ add_s inst =
 
 -- Make operation to set the carry flag to the value that it would have after an sub operation
 
-cf_sub_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> Stmt
+cf_sub_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 cf_sub_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagCf (ExtractNode (bv_size - 1) (bv_size - 1)
-      (BvxorNode
-        (BvxorNode op1ast (BvxorNode op2ast (ExtractNode (bv_size - 1) 0 parent)))
-        (BvandNode
-          (BvxorNode op1ast (ExtractNode (bv_size - 1) 0 parent))
-          (BvxorNode op1ast op2ast))))
+    set_flag X86FlagCf (ExtractExpr (bv_size - 1) (bv_size - 1)
+      (BvxorExpr
+        (BvxorExpr op1ast (BvxorExpr op2ast (ExtractExpr (bv_size - 1) 0 parent)))
+        (BvandExpr
+          (BvxorExpr op1ast (ExtractExpr (bv_size - 1) 0 parent))
+          (BvxorExpr op1ast op2ast))))
 
 -- Make operation to set the overflow flag to the value that it would have after an sub operation
 
-of_sub_s :: AstNode -> CsX86Op -> AstNode -> AstNode -> Stmt
+of_sub_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 of_sub_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    set_flag X86FlagOf (ExtractNode (bv_size - 1) (bv_size - 1)
-      (BvandNode
-        (BvxorNode op1ast op2ast)
-        (BvxorNode op1ast (ExtractNode (bv_size - 1) 0 parent))))
+    set_flag X86FlagOf (ExtractExpr (bv_size - 1) (bv_size - 1)
+      (BvandExpr
+        (BvxorExpr op1ast op2ast)
+        (BvxorExpr op1ast (ExtractExpr (bv_size - 1) 0 parent))))
 
 -- Make list of operations in the IR that has the same semantics as the X86 sub instruction
 
@@ -129,7 +129,7 @@ sub_s inst =
   let (op1 : op2 : _ ) = x86operands inst
       op1ast = getOperandAst op1
       op2ast = getOperandAst op2
-      sub_node = (BvsubNode op1ast op2ast)
+      sub_node = (BvsubExpr op1ast op2ast)
   in [
       store_node op1 sub_node,
       af_s sub_node op1 op1ast op1ast,
@@ -147,15 +147,15 @@ xor_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
       src_ast = getOperandAst src_op
-      xor_node = (BvxorNode dst_ast src_ast)
+      xor_node = (BvxorExpr dst_ast src_ast)
   in [
       store_node dst_op xor_node,
-      set_flag X86FlagAf UndefinedNode,
+      set_flag X86FlagAf UndefinedExpr,
       pf_s xor_node dst_op,
       sf_s xor_node dst_op,
       zf_s xor_node dst_op,
-      set_flag X86FlagCf (BvNode 0 1),
-      set_flag X86FlagOf (BvNode 0 1)
+      set_flag X86FlagCf (BvExpr 0 1),
+      set_flag X86FlagOf (BvExpr 0 1)
     ]
 
 -- Make list of operations in the IR that has the same semantics as the X86 and instruction
@@ -165,15 +165,15 @@ and_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
       src_ast = getOperandAst src_op
-      and_node = (BvandNode dst_ast src_ast)
+      and_node = (BvandExpr dst_ast src_ast)
   in [
       store_node dst_op and_node,
-      set_flag X86FlagAf UndefinedNode,
+      set_flag X86FlagAf UndefinedExpr,
       pf_s and_node dst_op,
       sf_s and_node dst_op,
       zf_s and_node dst_op,
-      set_flag X86FlagCf (BvNode 0 1),
-      set_flag X86FlagOf (BvNode 0 1)
+      set_flag X86FlagCf (BvExpr 0 1),
+      set_flag X86FlagOf (BvExpr 0 1)
     ]
 
 -- Make list of operations in the IR that has the same semantics as the X86 or instruction
@@ -183,15 +183,15 @@ or_s inst =
   let (dst_op : src_op : _ ) = x86operands inst
       dst_ast = getOperandAst dst_op
       src_ast = getOperandAst src_op
-      and_node = (BvorNode dst_ast src_ast)
+      and_node = (BvorExpr dst_ast src_ast)
   in [
       store_node dst_op and_node,
-      set_flag X86FlagAf UndefinedNode,
+      set_flag X86FlagAf UndefinedExpr,
       pf_s and_node dst_op,
       sf_s and_node dst_op,
       zf_s and_node dst_op,
-      set_flag X86FlagCf (BvNode 0 1),
-      set_flag X86FlagOf (BvNode 0 1)
+      set_flag X86FlagCf (BvExpr 0 1),
+      set_flag X86FlagOf (BvExpr 0 1)
     ]
 
 -- Make list of operations in the IR that has the same semantics as the X86 push instruction
@@ -206,8 +206,8 @@ push_s modes inst =
         (Imm _) -> arch_size
         _ -> convert $ size op1
   in [
-      SetReg sp (BvsubNode (GetReg sp) (BvNode op_size (arch_size * 8))),
-      Store op_size (GetReg sp) (ZxNode ((op_size - (convert $ size op1)) * 8) (getOperandAst op1))
+      SetReg sp (BvsubExpr (GetReg sp) (BvExpr op_size (arch_size * 8))),
+      Store op_size (GetReg sp) (ZxExpr ((op_size - (convert $ size op1)) * 8) (getOperandAst op1))
     ]
 
 -- Makes a singleton list containing the argument if the condition is true. Otherwise makes
@@ -233,11 +233,11 @@ pop_s modes inst =
         (Reg reg) -> isSubregisterOf (compoundReg reg) sp
         _ -> False
       -- An expression of the amount the stack pointer will be increased by
-      delta_val = (BvNode op_size (arch_size * 8))
+      delta_val = (BvExpr op_size (arch_size * 8))
   in
-    (includeIf sp_base [SetReg sp (BvaddNode (GetReg sp) delta_val)])
-    ++ [store_node op1 (Read op_size (if sp_base then (BvsubNode (GetReg sp) delta_val) else (GetReg sp)))]
-    ++ (includeIf (not (sp_base || sp_reg)) [SetReg sp (BvaddNode (GetReg sp) delta_val)])
+    (includeIf sp_base [SetReg sp (BvaddExpr (GetReg sp) delta_val)])
+    ++ [store_node op1 (Read op_size (if sp_base then (BvsubExpr (GetReg sp) delta_val) else (GetReg sp)))]
+    ++ (includeIf (not (sp_base || sp_reg)) [SetReg sp (BvaddExpr (GetReg sp) delta_val)])
 
 -- Make list of operations in the IR that has the same semantics as the X86 mov instruction
 
@@ -251,10 +251,10 @@ mov_s inst =
       -- avoid having to simulate the GDT. This definition allows users to
       -- directly define their segments offset.
       node = (case (value dst_op) of
-        (Reg reg) | is_segment_reg reg -> ExtractNode (word_size_bit - 1) 0 tmp_node
+        (Reg reg) | is_segment_reg reg -> ExtractExpr (word_size_bit - 1) 0 tmp_node
         _ -> tmp_node)
         where tmp_node = case (value src_op) of
-                (Reg reg) | is_segment_reg reg -> ExtractNode (dst_size_bit - 1) 0 src_ast
+                (Reg reg) | is_segment_reg reg -> ExtractExpr (dst_size_bit - 1) 0 src_ast
                 _ -> src_ast
       undef = case (value src_op) of
         (Reg reg) | is_control_reg reg -> True
@@ -264,12 +264,12 @@ mov_s inst =
   in
     [store_node dst_op node]
     ++ includeIf undef
-        [set_flag X86FlagAf UndefinedNode,
-        set_flag X86FlagPf UndefinedNode,
-        set_flag X86FlagSf UndefinedNode,
-        set_flag X86FlagZf UndefinedNode,
-        set_flag X86FlagCf UndefinedNode,
-        set_flag X86FlagOf UndefinedNode]
+        [set_flag X86FlagAf UndefinedExpr,
+        set_flag X86FlagPf UndefinedExpr,
+        set_flag X86FlagSf UndefinedExpr,
+        set_flag X86FlagZf UndefinedExpr,
+        set_flag X86FlagCf UndefinedExpr,
+        set_flag X86FlagOf UndefinedExpr]
 
 -- Make a list of operations in the IR that has the same semantics as the X86 jmp instruction
 
@@ -277,7 +277,7 @@ jmp_s :: CsInsn -> [Stmt]
 jmp_s inst =
   let (src_op : _ ) = x86operands inst
       src_ast = getOperandAst src_op
-  in [Branch (BvNode 1 1) src_ast]
+  in [Branch (BvExpr 1 1) src_ast]
 
 getCsX86arch :: Maybe CsDetail -> Maybe CsX86
 getCsX86arch inst =
@@ -304,7 +304,7 @@ get_arch_size modes =
   else if elem CsMode32 modes then 8
   else error "Processor modes underspecified."
 
-store_node :: CsX86Op -> AstNode -> Stmt
+store_node :: CsX86Op -> Expr -> Stmt
 store_node operand store_what =
   case (value operand) of
     (Reg reg) -> SetReg (compoundReg reg) store_what
@@ -314,5 +314,5 @@ store_node operand store_what =
 set_flag flag expr =
   let compReg = compoundReg X86RegEflags
       (low, high) = flagToBit flag
-    in SetReg compReg (ReplaceNode high low (GetReg compReg) expr)
+    in SetReg compReg (ReplaceExpr high low (GetReg compReg) expr)
     

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -23,6 +23,40 @@ inc_insn_ptr :: [CsMode] -> CsInsn -> Stmt
 
 inc_insn_ptr modes insn = SetReg (get_insn_ptr modes) (next_instr_ptr modes insn)
 
+-- Gets an expression for the given operand. Processor mode may be needed for computing
+-- effective addresses.
+
+getOperandAst :: [CsMode] -> CsX86Op -> Expr
+
+getOperandAst modes op = case value op of
+  (Imm value) -> BvExpr (convert value) (convert (size op) * 8)
+  (Reg reg) -> GetReg (compoundReg reg)
+  (Mem mem) -> Load (convert $ size op) (getLeaAst modes mem)
+
+-- Gets the specified register after it has been zero extended to the architecture size
+
+getZxRegister :: [CsMode] -> CompoundReg -> Expr
+
+getZxRegister modes reg =
+  ZxExpr (arch_size - reg_size) (GetReg reg) where
+    arch_size = get_arch_size modes
+    reg_size = getRegSize reg
+
+-- Gets an expression for the memory location of the given memory operand
+
+getLeaAst :: [CsMode] -> X86OpMemStruct -> Expr
+
+getLeaAst modes mem =
+  (BvaddExpr node_disp (BvaddExpr node_base node_index)) where
+    arch_size = get_arch_size modes
+    node_base = case base mem of
+      X86RegInvalid -> (BvExpr 0 arch_size)
+      reg -> getZxRegister modes (compoundReg reg)
+    node_index = case index mem of
+      X86RegInvalid -> (BvExpr 0 arch_size)
+      reg -> BvmulExpr (getZxRegister modes (compoundReg reg)) (BvExpr (fromIntegral $ scale mem) arch_size)
+    node_disp = BvExpr (fromIntegral $ disp' mem) arch_size
+
 -- Make operation to store the given expression in the given operand
 
 store_stmt :: [CsMode] -> CsX86Op -> Expr -> Stmt

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -274,9 +274,8 @@ mov_s inst =
 jmp_s :: CsInsn -> [Stmt]
 jmp_s inst =
   let (src_op : _ ) = x86operands inst
-  in case value src_op of
-    Imm rel -> [JccNode (BvNode 1 1) (convert (address inst + convert (length (bytes inst)) + rel))]
-    _ -> error "Absolute jumps not yet implemented."
+      src_ast = getOperandAst src_op
+  in [Branch (BvNode 1 1) src_ast]
 
 getCsX86arch :: Maybe CsDetail -> Maybe CsX86
 getCsX86arch inst =

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -271,6 +271,8 @@ mov_s inst =
         set_flag X86FlagCf UndefinedNode,
         set_flag X86FlagOf UndefinedNode]
 
+-- Make a list of operations in the IR that has the same semantics as the X86 jmp instruction
+
 jmp_s :: CsInsn -> [Stmt]
 jmp_s inst =
   let (src_op : _ ) = x86operands inst


### PR DESCRIPTION
Registers now specify bits as opposed to bytes in the register file. Registers are now pairs of extreme indicies instead of list of indicies. Flags are now treated like normal registers. Renamed Node to Expr. Processor mode now stored in ExecutionContext. Implemented JMP, JE, and LE. Instruction pointer now updated correctly. Now switching focus constant propagation, folding, ...