### PR TITLE
Numbered expressions

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -26,7 +26,8 @@ data X86Flag =
   | X86FlagDf | X86FlagOf | X86FlagIopl | X86FlagNt | X86FlagRf | X86FlagVm | X86FlagAc
   | X86FlagVif | X86FlagVip | X86FlagId deriving (Eq, Show)
 
--- A representation of a register as a list of indicies. Enables overlapping registers.
+-- A representation of a register as a pair indicating the lower (inclusive) and upper bit
+-- (exclusive) indicies. Enables overlapping registers.
 
 type CompoundReg = (Int, Int)
 
@@ -145,12 +146,6 @@ get_arch_byte_size modes =
 get_arch_bit_size :: [CsMode] -> Int
 
 get_arch_bit_size = (* 8) . get_arch_byte_size
-
--- Get the given bit of the integer
-
-getBit :: Int -> Int -> Int
-
-getBit value bit = if testBit value bit then 1 else 0
 
 data RegisterFile = RegisterFile {
   ranges :: [CompoundReg], -- The ranges where registers are defined
@@ -298,7 +293,7 @@ data Expr =
   | DistinctExpr Expr Expr
   | EqualExpr Expr Expr
   | ExtractExpr Int Int Expr -- ! `((_ extract <high> <low>) <expr>)` node
-  | ReplaceExpr Int Int Expr Expr
+  | ReplaceExpr Int Expr Expr
   | IffExpr Expr Expr -- ! `(iff <expr1> <expr2>)`
   | IteExpr Expr Expr Expr -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
   | LandExpr Expr Expr

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -256,7 +256,7 @@ data Expr =
   | LetExpr String Expr Expr
   | LnotExpr Expr
   | LorExpr Expr Expr
-  | ReferenceExpr --fix
+  | ReferenceExpr Int Int
   | StringExpr String
   | SxExpr Int Expr
   | VariableExpr
@@ -270,9 +270,14 @@ data Expr =
 -- are not composable.
 
 data Stmt =
-    Store Int Expr Expr
+    Store Expr Expr
   | SetReg CompoundReg Expr
   deriving (Eq, Show)
+
+-- Same as a statement but with an integer label to identify it. This type is necessary
+-- for the purposes of referring to past expressions
+
+type LbldStmt = (Int, Stmt)
 
 getExprSize :: Expr -> Int
 
@@ -321,6 +326,8 @@ getExprSize (LandExpr a b) = getExprSize a
 getExprSize (LnotExpr a) = getExprSize a
 
 getExprSize (LorExpr a b) = getExprSize a
+
+getExprSize (ReferenceExpr a b) = a
 
 getExprSize (SxExpr a b) = a + getExprSize b
 

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -30,14 +30,6 @@ basicX86Context modes stmts = ExecutionContext {
   proc_modes = modes
 }
 
--- Evaluates to a bit vector with all 1s up to bit high
-
-oneBitsUpto high = (shift 1 (high + 1)) - 1
-
--- Evaluates to a bit vector with all 1s between bit low and bit high
-
-oneBitsBetween high low = oneBitsUpto high - (oneBitsUpto (low - 1))
-
 -- Evaluates the given expression in the given context and returns the result
 
 eval :: ExecutionContext -> Expr -> BitVector

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -68,9 +68,9 @@ eval cin (ZxExpr a b) = zx a (eval cin b)
 eval cin (IteExpr a b c) =
   let abv = eval cin a in if equal abv (zero abv) then eval cin c else eval cin b
 
-eval cin (ReplaceExpr a b c d) = bvreplace (eval cin c) b (eval cin d)
+eval cin (ReplaceExpr b c d) = bvreplace (eval cin c) b (eval cin d)
 
-eval cin (ExtractExpr a b c) = bvextract b a (eval cin c)
+eval cin (ExtractExpr a b c) = bvextract a b (eval cin c)
 
 eval cin (GetReg bs) =
   case getRegisterValue (reg_file cin) bs of

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -90,12 +90,8 @@ exec :: ExecutionContext -> Stmt -> ExecutionContext
 
 -- Executes a SetReg operation by setting each byte of the register separately
 
-exec cin (SetReg bs a) = ExecutionContext {
-    reg_file = update_reg_file (reg_file cin) bs (eval cin a),
-    memory = memory cin,
-    stmts = stmts cin,
-    proc_modes = proc_modes cin
-  }
+exec cin (SetReg bs a) =
+  cin { reg_file = update_reg_file (reg_file cin) bs (eval cin a) }
 
 -- Executes a Store operation by setting each byte of memory separately
 
@@ -103,12 +99,7 @@ exec cin (Store n dst val) =
   let updateMemory mem 0 _ _ = mem
       updateMemory mem c d v =
         updateMemory (assign mem (d, (v .&. (bit byte_size_bit - 1)))) (c - 1) (d + 1) (shift v (-byte_size_bit))
-  in ExecutionContext {
-    reg_file = reg_file cin,
-    memory = updateMemory (memory cin) n (bvToInt (eval cin dst)) (bvToInt (eval cin val)),
-    stmts = stmts cin,
-    proc_modes = proc_modes cin
-  }
+  in cin { memory = updateMemory (memory cin) n (bvToInt (eval cin dst)) (bvToInt (eval cin val)) }
 
 -- Executes a group of statements pointed to by the instruction pointer and returns the
 -- new context

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -53,7 +53,7 @@ updateRegisterFile :: NumRegisterFile -> CompoundReg -> BitVector -> NumRegister
 updateRegisterFile reg_file reg val =
   let (ranges, _) = unzip reg_file
       new_ranges = addRegister ranges reg
-      undef_reg_file = map (\x -> (x, bitVector 0 (getRegSize x))) new_ranges
+      undef_reg_file = map (\x -> (x, bitVector 0 (getRegisterSize x))) new_ranges
       put reg_file (reg, value) = map (\(x, y) ->
         (x, if isSubregisterOf reg x then (let pos = fst (registerSub reg x) in bvreplace y pos value) else y)) reg_file
   in foldl put undef_reg_file (reg_file ++ [(reg, val)])

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -3,15 +3,84 @@ module EvalAst where
 import Ast
 import Hapstone.Internal.X86 as X86
 import Util
+import Data.List
 import Data.Bits
+import Data.Maybe
 import Hapstone.Internal.Capstone as Capstone
 import BitVector
+
+-- The RegisterFile is a map from registers to values
+
+type NumRegisterFile = [(CompoundReg, BitVector)]
+
+-- Gets all the register ranges in the RegisterFile
+
+ranges :: NumRegisterFile -> [CompoundReg]
+
+ranges = fst . unzip
+
+-- An empty register file for convenience
+
+emptyRegisterFile :: NumRegisterFile
+
+emptyRegisterFile = []
+
+-- Determines if the given register has a definite value in the register file
+
+isRegisterDefined :: NumRegisterFile -> CompoundReg -> Bool
+
+isRegisterDefined regFile reg = or (map (isSubregisterOf reg) (ranges regFile))
+
+getRegisterParent :: NumRegisterFile -> CompoundReg -> Maybe CompoundReg
+
+getRegisterParent regFile reg = find (isSubregisterOf reg . fst) regFile >>= Just . fst
+
+-- Gets the value of the specified compound register from the register file
+
+getRegisterValue :: NumRegisterFile -> CompoundReg -> Maybe BitVector
+
+getRegisterValue regFile reg =
+  case getRegisterParent regFile reg of
+    Just parentReg ->
+      let (l, h) = registerSub reg parentReg
+      in Just $ bvextract l h $ fromJust $ lookup parentReg regFile
+    Nothing -> Nothing
+
+-- Updates the given register file by putting the given value in the given register
+
+updateRegisterFile :: NumRegisterFile -> CompoundReg -> BitVector -> NumRegisterFile
+
+updateRegisterFile reg_file reg val =
+  let (ranges, _) = unzip reg_file
+      new_ranges = addRegister ranges reg
+      undef_reg_file = map (\x -> (x, bitVector 0 (getRegSize x))) new_ranges
+      put reg_file (reg, value) = map (\(x, y) ->
+        (x, if isSubregisterOf reg x then (let pos = fst (registerSub reg x) in bvreplace y pos value) else y)) reg_file
+  in foldl put undef_reg_file (reg_file ++ [(reg, val)])
+
+-- Get the register values from the register file
+
+getRegisterValues :: NumRegisterFile -> [(X86.X86Reg, BitVector)]
+
+getRegisterValues regFile =
+  map (\(x, y) -> (x, fromJust $ getRegisterValue regFile y)) (filter (isRegisterDefined regFile . snd) x86RegisterMap)
+
+-- Gets the specified bytes from memory
+
+getMemoryValue :: [(Int, Int)] -> [Int] -> Maybe BitVector
+
+getMemoryValue _ [] = Just empty
+
+getMemoryValue mem (b:bs) =
+  case (lookup b mem, getMemoryValue mem bs) of
+    (Just x, Just y) -> Just (bvconcat y (intToBv x))
+    _ -> Nothing
 
 -- Represents the state of a processor: register file contents, data memory contents, and
 -- the instruction memory.
 
-data ExecutionContext = ExecutionContext {
-  reg_file :: RegisterFile, -- Holds the contents and validity of the processor registers
+data NumExecutionContext = NumExecutionContext {
+  reg_file :: NumRegisterFile, -- Holds the contents and validity of the processor registers
   memory :: [(Int, Int)], -- Holds the contents and validity of the processor memory
   stmts :: [(Int, [Stmt])], -- Holds the instructions to be executed and their memory addresses
   proc_modes :: [CsMode] -- Holds the processor information that effects interpretation of instructions
@@ -20,19 +89,19 @@ data ExecutionContext = ExecutionContext {
 -- Creates a context where the instruction pointer points to the first instruction, and
 -- memory and the register file are empty.
 
-basicX86Context :: [CsMode] -> [(Int, [Stmt])] -> ExecutionContext
+basicX86Context :: [CsMode] -> [(Int, [Stmt])] -> NumExecutionContext
 
-basicX86Context modes stmts = ExecutionContext {
+basicX86Context modes stmts = NumExecutionContext {
   memory = [],
   -- Point the instruction pointer to the first instruction on the list
-  reg_file = update_reg_file emptyRegisterFile (get_insn_ptr modes) (bitVector (convert (fst (head stmts))) (get_arch_bit_size modes)),
+  reg_file = updateRegisterFile emptyRegisterFile (get_insn_ptr modes) (bitVector (convert (fst (head stmts))) (get_arch_bit_size modes)),
   stmts = stmts,
   proc_modes = modes
 }
 
 -- Evaluates the given expression in the given context and returns the result
 
-eval :: ExecutionContext -> Expr -> BitVector
+eval :: NumExecutionContext -> Expr -> BitVector
 
 eval cin (BvExpr a) = a
 
@@ -86,12 +155,12 @@ assign ((c, d) : es) (a, b) | c == a = (a, b) : es
 
 assign ((c, d) : es) (a, b) | c /= a = (c, d) : assign es (a, b)
 
-exec :: ExecutionContext -> Stmt -> ExecutionContext
+exec :: NumExecutionContext -> Stmt -> NumExecutionContext
 
 -- Executes a SetReg operation by setting each byte of the register separately
 
 exec cin (SetReg bs a) =
-  cin { reg_file = update_reg_file (reg_file cin) bs (eval cin a) }
+  cin { reg_file = updateRegisterFile (reg_file cin) bs (eval cin a) }
 
 -- Executes a Store operation by setting each byte of memory separately
 
@@ -104,7 +173,7 @@ exec cin (Store n dst val) =
 -- Executes a group of statements pointed to by the instruction pointer and returns the
 -- new context
 
-step :: ExecutionContext -> ExecutionContext
+step :: NumExecutionContext -> NumExecutionContext
 
 step cin =
   let procInsnPtr = get_insn_ptr (proc_modes cin)

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -164,11 +164,11 @@ exec cin (SetReg bs a) =
 
 -- Executes a Store operation by setting each byte of memory separately
 
-exec cin (Store n dst val) =
+exec cin (Store dst val) =
   let updateMemory mem 0 _ _ = mem
       updateMemory mem c d v =
         updateMemory (assign mem (d, (v .&. (bit byte_size_bit - 1)))) (c - 1) (d + 1) (shift v (-byte_size_bit))
-  in cin { memory = updateMemory (memory cin) n (bvToInt (eval cin dst)) (bvToInt (eval cin val)) }
+  in cin { memory = updateMemory (memory cin) (getExprSize val) (bvToInt (eval cin dst)) (bvToInt (eval cin val)) }
 
 -- Executes a group of statements pointed to by the instruction pointer and returns the
 -- new context

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import System.IO
 import Hapstone.Internal.Capstone as Capstone
-import EvalAst
+--import EvalAst
 import Ast
 import SymbolicEval
 import BitVector
@@ -16,13 +16,13 @@ main = do
   print "this should be in test/"
   -- Ignoring the changes to the flag registers, the following is what happens
 
-  let input = [0xBC, 0x00, 0x00, 0x00, 0x80, 0xB8, 0x37, 0x13, 0x22, 0x00, 0x50, 0xB8, 0x01, 0x00, 0x00, 0x00, 0x58, 0xB8, 0x02, 0x00, 0x00, 0x00]
+  let input = [0xB8, 0x02, 0x00, 0x00, 0x00]
       modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   let lifted = case asm of
                   Left _ -> error "error on disasm"
                   Right b -> liftAsm modes b
       oneblock = foldl (\y (a, b) -> y ++ b) [] lifted
-  print lifted
-  print oneblock
+  -- print lifted
+  -- print oneblock
   print (symSteps (basicX86Context modes lifted))

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -16,7 +16,7 @@ main = do
   print "this should be in test/"
   -- Ignoring the changes to the flag registers, the following is what happens
 
-  let input = [0xB8, 0x02, 0x00, 0x00, 0x00, 0xB8, 0x02, 0x00, 0x00, 0x00]
+  let input = [0xBC, 0x64, 0x00, 0x00, 0x00, 0x50, 0xB8, 0x02, 0x00, 0x00, 0x00, 0x83, 0xC0, 0x0A, 0x58, 0x83, 0xE8, 0x03]
       modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   let lifted = case asm of
@@ -25,4 +25,4 @@ main = do
       oneblock = foldl (\y (a, b) -> y ++ b) [] lifted
   -- print lifted
   -- print oneblock
-  print (getRegisterValues (reg_file (fst (symSteps (basicX86Context modes lifted)))))
+  print {-(getRegisterValues (reg_file (fst-} (symSteps (labelStmts lifted) (basicX86Context modes)){-)))-}

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -16,7 +16,7 @@ main = do
   print "this should be in test/"
   -- Ignoring the changes to the flag registers, the following is what happens
 
-  let input = [0xB8, 0x02, 0x00, 0x00, 0x00]
+  let input = [0xB8, 0x02, 0x00, 0x00, 0x00, 0xB8, 0x02, 0x00, 0x00, 0x00]
       modes = [Capstone.CsMode32]
   asm <- disasm_buf modes input
   let lifted = case asm of
@@ -25,4 +25,4 @@ main = do
       oneblock = foldl (\y (a, b) -> y ++ b) [] lifted
   -- print lifted
   -- print oneblock
-  print (symSteps (basicX86Context modes lifted))
+  print (getRegisterValues (reg_file (fst (symSteps (basicX86Context modes lifted)))))

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -114,11 +114,11 @@ getMemoryValue :: [(Int, Expr)] -> (Int, Int) -> Expr
 getMemoryValue mem (a,b) =
   let exprSize = (b-a) * byte_size_bit
       setByte expr offset =
-        ReplaceExpr (offset*byte_size_bit) expr $
+        replaceExpr (offset*byte_size_bit) expr $
           case lookup (a+offset) mem of
             Just x -> x
             _ -> Load 1 (BvExpr $ intToBv (a+offset))
-  in foldl setByte (UndefinedExpr exprSize) [0..b-a]
+  in foldl setByte (UndefinedExpr exprSize) [0..b-a-1]
 
 -- Represents the state of a processor: register file contents, data memory contents, and
 -- the instruction memory.
@@ -212,7 +212,7 @@ symEval cin (Load a b) =
   case (symEval cin b) of
     (BvExpr memStartBv) ->
       let memStart = bvToInt memStartBv
-      in getMemoryValue (memory cin) (memStart,memStart + a - 1)
+      in getMemoryValue (memory cin) (memStart,memStart + a)
     (b) -> Load a b
 
 symEval cin expr = expr

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -1,16 +1,122 @@
 module SymbolicEval where
 
-import EvalAst
 import Ast
 import Hapstone.Internal.X86 as X86
 import Util
 import Data.Bits
+import Data.List
+import Data.Maybe
 import Hapstone.Internal.Capstone as Capstone
 import BitVector
 
+-- Assigns the given value to the given key. Adds a new association to the list if necessary
+
+assign :: Eq a => [(a,b)] -> (a, b) -> [(a, b)]
+
+assign [] (a, b) = [(a, b)]
+
+assign ((c, d) : es) (a, b) | c == a = (a, b) : es
+
+assign ((c, d) : es) (a, b) | c /= a = (c, d) : assign es (a, b)
+
+-- The RegisterFile is a map from registers to values
+
+type SymRegisterFile = [(CompoundReg, Expr)]
+
+-- Gets all the register ranges in the RegisterFile
+
+ranges :: SymRegisterFile -> [CompoundReg]
+
+ranges = fst . unzip
+
+-- An empty register file for convenience
+
+emptyRegisterFile :: SymRegisterFile
+
+emptyRegisterFile = []
+
+-- Determines if the given register has a definite value in the register file
+
+isRegisterDefined :: SymRegisterFile -> CompoundReg -> Bool
+
+isRegisterDefined regFile reg = or (map (isSubregisterOf reg) (ranges regFile))
+
+getRegisterParent :: SymRegisterFile -> CompoundReg -> Maybe CompoundReg
+
+getRegisterParent regFile reg = find (isSubregisterOf reg . fst) regFile >>= Just . fst
+
+-- Gets the value of the specified compound register from the register file
+
+getRegisterValue :: SymRegisterFile -> CompoundReg -> Maybe Expr
+
+getRegisterValue regFile reg =
+  case getRegisterParent regFile reg of
+    Just parentReg ->
+      let (l, h) = registerSub reg parentReg
+      in Just $ ExtractExpr l h $ fromJust $ lookup parentReg regFile
+    Nothing -> Nothing
+
+-- Updates the given register file by putting the given value in the given register
+
+setRegisterValue :: SymRegisterFile -> CompoundReg -> Expr -> SymRegisterFile
+
+setRegisterValue reg_file reg val =
+  let (ranges, _) = unzip reg_file
+      new_ranges = addRegister ranges reg
+      undef_reg_file = map (\x -> (x, UndefinedExpr (getRegSize x))) new_ranges
+      put reg_file (reg, value) = map (\(x, y) ->
+        (x, if isSubregisterOf reg x then (let pos = fst (registerSub reg x) in ReplaceExpr pos y value) else y)) reg_file
+  in foldl put undef_reg_file (reg_file ++ [(reg, val)])
+
+-- Updates the register file by removing the value in the given register
+
+unsetRegisterValue :: SymRegisterFile -> CompoundReg -> SymRegisterFile
+
+unsetRegisterValue regFile reg =
+  let (ranges, _) = unzip regFile
+      newRanges = removeRegister ranges reg
+  in map (\x -> (x, fromJust $ getRegisterValue regFile x)) newRanges
+
+-- Get the register values from the register file
+
+getRegisterValues regFile =
+  map (\(x, y) -> (x, getRegisterValue regFile y)) (filter (isRegisterDefined regFile . snd) x86RegisterMap)
+
+-- Gets the specified bytes from memory
+
+getMemoryValue :: [(Int, Int)] -> [Int] -> Maybe BitVector
+
+getMemoryValue _ [] = Just empty
+
+getMemoryValue mem (b:bs) =
+  case (lookup b mem, getMemoryValue mem bs) of
+    (Just x, Just y) -> Just (bvconcat y (intToBv x))
+    _ -> Nothing
+
+-- Represents the state of a processor: register file contents, data memory contents, and
+-- the instruction memory.
+
+data SymExecutionContext = SymExecutionContext {
+  reg_file :: SymRegisterFile, -- Holds the contents and validity of the processor registers
+  memory :: [(Int, Int)], -- Holds the contents and validity of the processor memory
+  stmts :: [(Int, [Stmt])], -- Holds the instructions to be executed and their memory addresses
+  proc_modes :: [CsMode] -- Holds the processor information that effects interpretation of instructions
+} deriving (Eq, Show)
+
+-- Creates a context where the memory and the register file are empty.
+
+basicX86Context :: [CsMode] -> [(Int, [Stmt])] -> SymExecutionContext
+
+basicX86Context modes stmts = SymExecutionContext {
+  memory = [],
+  reg_file = emptyRegisterFile,
+  stmts = stmts,
+  proc_modes = modes
+}
+
 -- Simplifies the given expression in the given context
 
-symEval :: ExecutionContext -> Expr -> Expr
+symEval :: SymExecutionContext -> Expr -> Expr
 
 symEval cin (BvxorExpr c d) =
   case (symEval cin c, symEval cin d) of
@@ -72,11 +178,7 @@ symEval cin (ExtractExpr a b c) =
     (BvExpr d) -> BvExpr (bvextract a b d)
     (c) -> ExtractExpr a b c
 
-symEval cin (GetReg bs) =
-  let regVal = getRegisterValue (reg_file cin) bs
-  in case regVal of
-    Just x -> BvExpr x
-    Nothing -> GetReg bs
+symEval cin (GetReg bs) = fromJust $ getRegisterValue (reg_file cin) bs
 
 -- add ro memory (raise exception if written)
 -- add symbolic addressed memory (example stack, no concrete values mapping references)
@@ -93,7 +195,7 @@ symEval cin (Load a b) =
 
 symEval cin expr = expr
 
-symExec :: ExecutionContext -> Stmt -> (ExecutionContext, Stmt)
+symExec :: SymExecutionContext -> Stmt -> (SymExecutionContext, Stmt)
 
 -- Symbolically executes a SetReg operation by either simplifying assignment value to a
 -- literal then putting it into the register file, or by undefining the target register
@@ -101,12 +203,7 @@ symExec :: ExecutionContext -> Stmt -> (ExecutionContext, Stmt)
 
 symExec cin (SetReg bs a) =
   let c = symEval cin a
-      nreg = case c of
-        BvExpr a -> update_reg_file (reg_file cin) bs a
-        _ -> let treg_file = reg_file cin
-                 old_ranges = ranges treg_file
-                 tvalues = values treg_file
-              in RegisterFile {ranges = removeRegister old_ranges bs, values = tvalues}
+      nreg = setRegisterValue (reg_file cin) bs c
   in (cin { reg_file = nreg }, SetReg bs c)
 
 
@@ -119,7 +216,8 @@ symExec cin (Store n dst val) =
         BvExpr a -> (updateMemory cin (bytes (bvlength a)) (bvToInt a) 0x1337, Store n pdest pval)
         _ -> error $ "Store on symbolic mem not implemented"
 
-updateMemory :: ExecutionContext -> Int -> Int -> Int -> ExecutionContext
+updateMemory :: SymExecutionContext -> Int -> Int -> Int -> SymExecutionContext
+
 updateMemory cin bc address val =
     let nmem = foldl (\mem x -> assign mem ((address+x), (shift val (0-(8 * x))) .&. 0xff)) (memory cin) [0..bc-1]
     in cin { memory = nmem }
@@ -127,7 +225,7 @@ updateMemory cin bc address val =
 -- Executes a group of statements pointed to by the instruction pointer and returns the
 -- new context
 
-symSteps :: ExecutionContext -> (ExecutionContext, [(Int, [Stmt])])
+symSteps :: SymExecutionContext -> (SymExecutionContext, [(Int, [Stmt])])
 
 symSteps cin | stmts cin == [] = (cin, [])
 
@@ -142,3 +240,4 @@ symSteps cin =
           (fec, ent) = process cin x []
           (ffec, ents) = symSteps fec
       in (ffec, (ent:ents))
+

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -62,17 +62,15 @@ symEval cin (IteExpr a b c) =
     (BvExpr a, b, c) -> if equal a (zero a) then c else b
     (a, b, c) -> IteExpr a b c
 
-{-symEval cin (ReplaceExpr a b c d) =
+symEval cin (ReplaceExpr b c d) =
   case (symEval cin c, symEval cin d) of
-    (BvExpr c cn, BvExpr d dn) | dn == b+1-a ->
-      BvExpr ((c .&. (complement (oneBitsBetween a b))) .|. shift d b) cn
-    (BvExpr _ _, BvExpr _ _) -> error "Size of replacement bit-vector does not match target space."
-    (c, d) -> ReplaceExpr a b c d
+    (BvExpr cbv, BvExpr dbv) -> BvExpr (bvreplace cbv b dbv)
+    (c, d) -> ReplaceExpr b c d
 
 symEval cin (ExtractExpr a b c) =
   case (symEval cin c) of
-    (BvExpr c cn) -> BvExpr ((shift c (-b)) .&. (oneBitsUpto (a + 1 - b))) (a + 1 - b)
-    (c) -> ExtractExpr a b c-}
+    (BvExpr d) -> BvExpr (bvextract a b d)
+    (c) -> ExtractExpr a b c
 
 symEval cin (GetReg bs) =
   let regVal = getRegisterValue (reg_file cin) bs

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -51,7 +51,7 @@ getZxRegister :: [CsMode] -> CompoundReg -> Expr
 getZxRegister modes reg =
   ZxExpr (arch_bit_size - reg_size) (GetReg reg) where
     arch_bit_size = get_arch_bit_size modes
-    reg_size = getRegSize reg
+    reg_size = getRegisterSize reg
 
 -- Gets an expression for the memory location of the given memory operand
 

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -268,7 +268,7 @@ xor_s modes inst =
   in [
       inc_insn_ptr modes inst,
       store_stmt modes dst_op xor_node,
-      SetReg (fromX86Flag X86FlagAf) UndefinedExpr,
+      SetReg (fromX86Flag X86FlagAf) (UndefinedExpr 1),
       pf_s xor_node dst_op,
       sf_s xor_node dst_op,
       zf_s xor_node dst_op,
@@ -288,7 +288,7 @@ and_s modes inst =
   in [
       inc_insn_ptr modes inst,
       store_stmt modes dst_op and_node,
-      SetReg (fromX86Flag X86FlagAf) UndefinedExpr,
+      SetReg (fromX86Flag X86FlagAf) (UndefinedExpr 1),
       pf_s and_node dst_op,
       sf_s and_node dst_op,
       zf_s and_node dst_op,
@@ -308,7 +308,7 @@ or_s modes inst =
   in [
       inc_insn_ptr modes inst,
       store_stmt modes dst_op and_node,
-      SetReg (fromX86Flag X86FlagAf) UndefinedExpr,
+      SetReg (fromX86Flag X86FlagAf) (UndefinedExpr 1),
       pf_s and_node dst_op,
       sf_s and_node dst_op,
       zf_s and_node dst_op,
@@ -393,12 +393,12 @@ mov_s modes inst =
     [inc_insn_ptr modes inst,
     store_stmt modes dst_op node]
     ++ includeIf undef
-        [SetReg (fromX86Flag X86FlagAf) UndefinedExpr,
-        SetReg (fromX86Flag X86FlagPf) UndefinedExpr,
-        SetReg (fromX86Flag X86FlagSf) UndefinedExpr,
-        SetReg (fromX86Flag X86FlagZf) UndefinedExpr,
-        SetReg (fromX86Flag X86FlagCf) UndefinedExpr,
-        SetReg (fromX86Flag X86FlagOf) UndefinedExpr]
+        [SetReg (fromX86Flag X86FlagAf) (UndefinedExpr 1),
+        SetReg (fromX86Flag X86FlagPf) (UndefinedExpr 1),
+        SetReg (fromX86Flag X86FlagSf) (UndefinedExpr 1),
+        SetReg (fromX86Flag X86FlagZf) (UndefinedExpr 1),
+        SetReg (fromX86Flag X86FlagCf) (UndefinedExpr 1),
+        SetReg (fromX86Flag X86FlagOf) (UndefinedExpr 1)]
 
 
 -- Make a list of operations in the IR that has the same semantics as the X86 jmp instruction

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -75,7 +75,7 @@ store_stmt :: [CsMode] -> CsX86Op -> Expr -> Stmt
 store_stmt modes operand store_what =
   case (value operand) of
     (Reg reg) -> SetReg (fromX86Reg reg) store_what
-    (Mem mem) -> Store (convert $ size operand) (getLeaAst modes mem) store_what
+    (Mem mem) -> Store (getLeaAst modes mem) store_what
     _ -> error "Target of store operation is neither a register nor a memory operand."
 
 -- Make operation to set the zero flag to the value that it would have after some operation
@@ -331,7 +331,7 @@ push_s modes inst =
   in [
       inc_insn_ptr modes inst,
       SetReg sp (BvsubExpr (GetReg sp) (BvExpr (bitVector (convert op_size) (arch_byte_size * 8)))),
-      Store op_size (GetReg sp) (ZxExpr ((op_size - (convert $ size src)) * 8) (getOperandAst modes src))
+      Store (GetReg sp) (ZxExpr ((op_size - (convert $ size src)) * 8) (getOperandAst modes src))
     ]
 
 -- Makes a singleton list containing the argument if the condition is true. Otherwise makes

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -85,7 +85,7 @@ zf_s :: Expr -> CsX86Op -> Stmt
 zf_s parent dst =
   let bv_size = (convert $ size dst) * 8 in
     SetReg (fromX86Flag X86FlagZf) (IteExpr
-      (EqualExpr (ExtractExpr bv_size 0 parent) (BvExpr (bitVector 0 bv_size)))
+      (EqualExpr (ExtractExpr 0 bv_size parent) (BvExpr (bitVector 0 bv_size)))
       (BvExpr (bitVector 1 1))
       (BvExpr (bitVector 0 1)))
 
@@ -95,10 +95,10 @@ of_add_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 
 of_add_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    SetReg (fromX86Flag X86FlagOf) (ExtractExpr bv_size (bv_size - 1)
+    SetReg (fromX86Flag X86FlagOf) (ExtractExpr (bv_size - 1) bv_size
       (BvandExpr
         (BvxorExpr op1ast (BvnotExpr op2ast))
-        (BvxorExpr op1ast (ExtractExpr bv_size 0 parent))))
+        (BvxorExpr op1ast (ExtractExpr 0 bv_size parent))))
 
 -- Make operation to set the carry flag to the value that it would have after an add operation
 
@@ -106,11 +106,11 @@ cf_add_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 
 cf_add_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    SetReg (fromX86Flag X86FlagCf) (ExtractExpr bv_size (bv_size - 1)
+    SetReg (fromX86Flag X86FlagCf) (ExtractExpr (bv_size - 1) bv_size
       (BvxorExpr (BvandExpr op1ast op2ast)
         (BvandExpr (BvxorExpr
             (BvxorExpr op1ast op2ast)
-            (ExtractExpr bv_size 0 parent))
+            (ExtractExpr 0 bv_size parent))
           (BvxorExpr op1ast op2ast))))
 
 -- Make operation to set the adjust flag to the value that it would have after some operation
@@ -125,7 +125,7 @@ af_s parent dst op1ast op2ast =
         (BvandExpr
           (BvExpr (bitVector 0x10 bv_size))
           (BvxorExpr
-            (ExtractExpr bv_size 0 parent)
+            (ExtractExpr 0 bv_size parent)
             (BvxorExpr op1ast op2ast))))
       (BvExpr (bitVector 1 1))
       (BvExpr (bitVector 0 1)))
@@ -140,9 +140,9 @@ pf_s parent dst =
           then BvExpr (bitVector 1 1)
           else (BvxorExpr
             (loop (counter + 1))
-            (ExtractExpr 1 0
+            (ExtractExpr 0 1
               (BvlshrExpr
-                (ExtractExpr byte_size_bit 0 parent)
+                (ExtractExpr 0 byte_size_bit parent)
                 (BvExpr (bitVector counter byte_size_bit)))))) in
     SetReg (fromX86Flag X86FlagPf) (loop 0)
 
@@ -152,7 +152,7 @@ sf_s :: Expr -> CsX86Op -> Stmt
 
 sf_s parent dst =
   let bv_size = (convert $ size dst) * 8 in
-    SetReg (fromX86Flag X86FlagSf) (ExtractExpr bv_size (bv_size - 1) parent)
+    SetReg (fromX86Flag X86FlagSf) (ExtractExpr (bv_size - 1) bv_size parent)
 
 -- Make list of operations in the IR that has the same semantics as the X86 add instruction
 
@@ -199,11 +199,11 @@ cf_sub_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 
 cf_sub_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    SetReg (fromX86Flag X86FlagCf) (ExtractExpr bv_size (bv_size - 1)
+    SetReg (fromX86Flag X86FlagCf) (ExtractExpr (bv_size - 1) bv_size
       (BvxorExpr
-        (BvxorExpr op1ast (BvxorExpr op2ast (ExtractExpr bv_size 0 parent)))
+        (BvxorExpr op1ast (BvxorExpr op2ast (ExtractExpr 0 bv_size parent)))
         (BvandExpr
-          (BvxorExpr op1ast (ExtractExpr bv_size 0 parent))
+          (BvxorExpr op1ast (ExtractExpr 0 bv_size parent))
           (BvxorExpr op1ast op2ast))))
 
 -- Make operation to set the overflow flag to the value that it would have after an sub operation
@@ -212,10 +212,10 @@ of_sub_s :: Expr -> CsX86Op -> Expr -> Expr -> Stmt
 
 of_sub_s parent dst op1ast op2ast =
   let bv_size = (convert $ size dst) * 8 in
-    SetReg (fromX86Flag X86FlagOf) (ExtractExpr bv_size (bv_size - 1)
+    SetReg (fromX86Flag X86FlagOf) (ExtractExpr (bv_size - 1) bv_size
       (BvandExpr
         (BvxorExpr op1ast op2ast)
-        (BvxorExpr op1ast (ExtractExpr bv_size 0 parent))))
+        (BvxorExpr op1ast (ExtractExpr 0 bv_size parent))))
 
 -- Make list of operations in the IR that has the same semantics as the X86 sub instruction
 
@@ -379,10 +379,10 @@ mov_s modes inst =
       -- avoid having to simulate the GDT. This definition allows users to
       -- directly define their segments offset.
       node = (case (value dst_op) of
-        (Reg reg) | is_segment_reg reg -> ExtractExpr word_size_bit 0 tmp_node
+        (Reg reg) | is_segment_reg reg -> ExtractExpr 0 word_size_bit tmp_node
         _ -> tmp_node)
         where tmp_node = case (value src_op) of
-                (Reg reg) | is_segment_reg reg -> ExtractExpr dst_size_bit 0 src_ast
+                (Reg reg) | is_segment_reg reg -> ExtractExpr 0 dst_size_bit src_ast
                 _ -> src_ast
       undef = case (value src_op) of
         (Reg reg) | is_control_reg reg -> True
@@ -436,7 +436,7 @@ lea_s modes inst =
         if dst_size > src_ea_size then
           ZxExpr (dst_size - src_ea_size) src_ea
         else if dst_size < src_ea_size then
-          ExtractExpr dst_size 0 src_ea
+          ExtractExpr 0 dst_size src_ea
         else src_ea
   in [
       inc_insn_ptr modes inst,


### PR DESCRIPTION
Numbered the statements coming from X86Sem. Now use ReferenceExpr to refer back to previous expressions. Registers and memory now contain values of the Expr type. Memory is byte addressed, as was suggested. Still need to implement assignments to symbolic addresses. Need to simplify values when they are drawn from memory (lots of concatenations).

Example of what program can now do:

add eax, 5
mov ebx, eax
mov eax, 2
add eax, 10
mov eax, ebx
sub eax, 3

Goes to:

(1,SetReg (0,32) (BvaddExpr (GetReg (0,32)) (BvExpr ([5],32)))),
(9,SetReg (64,96) (ReferenceExpr 32 1))]),
(11,SetReg (0,32) (BvExpr ([2],32)))]),
(13,SetReg (0,32) (BvExpr ([12],32))),
(21,SetReg (0,32) (ReferenceExpr 32 1))]),
(23,SetReg (0,32) (BvsubExpr (ReferenceExpr 32 1) (BvExpr ([3],32)))),