### PR TITLE
Dead code elimination

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -212,58 +212,82 @@ is_control_reg reg = elem reg
 -- context but are composable.
 
 data Expr =
-    BvaddExpr Expr Expr
-  | BvandExpr Expr Expr
-  | BvashrExpr Expr Expr
-  | BvlshrExpr Expr Expr
-  | BvmulExpr Expr Expr
-  | BvnandExpr Expr Expr
-  | BvnegExpr Expr
-  | BvnorExpr Expr Expr
-  | BvnotExpr Expr
-  | BvorExpr Expr Expr
-  | BvrolExpr Expr Expr
-  | BvrorExpr Expr Expr -- can lit
-  | BvsdivExpr Expr Expr
-  | BvsgeExpr Expr Expr
-  | BvsgtExpr Expr Expr
-  | BvshlExpr Expr Expr
-  | BvsleExpr Expr Expr
-  | BvsltExpr Expr Expr
-  | BvsmodExpr Expr Expr
-  | BvsremExpr Expr Expr
-  | BvsubExpr Expr Expr
-  | BvudivExpr Expr Expr
-  | BvugeExpr Expr Expr
-  | BvugtExpr Expr Expr
-  | BvuleExpr Expr Expr
-  | BvultExpr Expr Expr
-  | BvuremExpr Expr Expr
-  | BvxnorExpr Expr Expr
-  | BvxorExpr Expr Expr
-  | BvExpr BitVector
+  -- Literal bit-vector. The size of this expression equals that of the bit-vector.
+  BvExpr BitVector
+  
+  -- The following operations take and return equally sized operands
+  | BvaddExpr Expr Expr -- Add
+  | BvandExpr Expr Expr -- Bitwise and
+  | BvashrExpr Expr Expr -- Arithmetic shift right
+  | BvlshrExpr Expr Expr -- Logical shift right
+  | BvmulExpr Expr Expr -- Multiply
+  | BvnandExpr Expr Expr -- Bitwise nand
+  | BvnegExpr Expr -- Negate
+  | BvnorExpr Expr Expr -- Bitwise nor
+  | BvnotExpr Expr -- Bitwise not
+  | BvorExpr Expr Expr -- Bitwise or
+  | BvrolExpr Expr Expr -- Rotate left
+  | BvrorExpr Expr Expr -- Rotate right
+  | BvsdivExpr Expr Expr -- Signed division
+  | BvsgeExpr Expr Expr -- Signed greater than or equal
+  | BvsgtExpr Expr Expr -- Signed greater than
+  | BvshlExpr Expr Expr -- Shift left
+  | BvsleExpr Expr Expr -- Signed less than or equal
+  | BvsltExpr Expr Expr -- Signed less than
+  | BvsmodExpr Expr Expr -- Signed modulo
+  | BvsremExpr Expr Expr -- Signed remainder
+  | BvsubExpr Expr Expr -- Subtraction
+  | BvudivExpr Expr Expr -- Unsigned division
+  | BvugeExpr Expr Expr -- Unsigned greater than or equal
+  | BvugtExpr Expr Expr -- Unsigned greater than
+  | BvuleExpr Expr Expr -- Unsigned less than or equal
+  | BvultExpr Expr Expr -- Unsigned less than
+  | BvuremExpr Expr Expr -- Unsigned remainder
+  | BvxnorExpr Expr Expr -- Bitwise xnor
+  | BvxorExpr Expr Expr -- Bitwise xor
+  | EqualExpr Expr Expr -- Returns 1 is equal, 0 otherwise
+  | IteExpr Expr Expr Expr -- If first expression is non-zero then return second, otherwise third
+  | LandExpr Expr Expr -- Logical and
+  | LnotExpr Expr -- Logical not
+  | LorExpr Expr Expr -- Logical or
+  
+  -- Takes in order the low bit index (inclusive), the high bit index (exclusive), and the
+  -- expression from which to extract. Size of resulting expression is the difference
+  -- between the indicies.
+  | ExtractExpr Int Int Expr
+  -- Takes in order the low bit index (inclusive), the expression whose part starting at
+  -- the aforementioned bit is to be replaced, and the expression that is to be used as
+  -- the replacement. Size of returned expression equals that of first supplied expression.
+  | ReplaceExpr Int Expr Expr
+  -- Takes in order the size of the expression that is being referenced, and the
+  -- identifier of the expression being reference. Size of this expression equals the size
+  -- of the expression being referenced.
+  | ReferenceExpr Int Int
+  -- Sign extends the given expression by the given amount. Size of this expression equals
+  -- the sum of the given amount and the size of the given expression.
+  | SxExpr Int Expr
+  -- Zero extends the given expression by the given amount. Size of this expression equals
+  -- the sum of the given amount and the size of the given expression.
+  | ZxExpr Int Expr
+  -- An undefined expression of the given size.
+  | UndefinedExpr Int
+  -- Takes in order the number of bytes to extract from memory, and the address in memory
+  -- from which to obtain data. Size of this expression equals the number of bits to be
+  -- extracted from memory.
+  | Load Int Expr
+  -- Obtains the value of the given register. The size of this expression equals the size,
+  -- in bits, of the register.
+  | GetReg CompoundReg
+  
   | CompoundExpr -- ! `[<expr1> <expr2> <expr3> ...]` node
   | ConcatExpr [Expr]
   | DecimalExpr Int --float?
   | DeclareExpr --wtf?
   | DistinctExpr Expr Expr
-  | EqualExpr Expr Expr
-  | ExtractExpr Int Int Expr -- ! `((_ extract <high> <low>) <expr>)` node
-  | ReplaceExpr Int Expr Expr
   | IffExpr Expr Expr -- ! `(iff <expr1> <expr2>)`
-  | IteExpr Expr Expr Expr -- ! `(ite <ifExpr> <thenExpr> <elseExpr>)`
-  | LandExpr Expr Expr
   | LetExpr String Expr Expr
-  | LnotExpr Expr
-  | LorExpr Expr Expr
-  | ReferenceExpr Int Int
   | StringExpr String
-  | SxExpr Int Expr
   | VariableExpr
-  | ZxExpr Int Expr
-  | UndefinedExpr Int -- The undefined value
-  | Load Int Expr
-  | GetReg CompoundReg
   deriving (Eq, Show)
 
 -- The statements that the machine code will be lifted to. Statements modify context and

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -374,7 +374,8 @@ getExprSize (Load a b) = a * byte_size_bit
 
 getExprSize (GetReg a) = getRegisterSize a
 
--- Creates a post-ordered list of expressions from the given expression
+-- Creates a post-ordered list of expressions from the given expression. Sometimes the
+-- hierarchy is a hindrance in computations.
 
 flatten :: Expr -> [Expr]
 
@@ -435,4 +436,67 @@ flatten (UndefinedExpr a) = [UndefinedExpr a]
 flatten (Load a b) = flatten b ++ [Load a b]
 
 flatten (GetReg a) = [GetReg a]
+
+-- Going through the expression tree in post-order, map expressions to other expressions
+-- using the given function.
+
+mapExpr :: (Expr -> Expr) -> Expr -> Expr
+
+mapExpr f (BvExpr bv) = f (BvExpr bv)
+
+mapExpr f (BvaddExpr a b) = f $ BvaddExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvandExpr a b) = f $ BvandExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvashrExpr a b) = f $ BvashrExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvlshrExpr a b) = f $ BvlshrExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvnandExpr a b) = f $ BvnandExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvnegExpr a) = f $ BvnegExpr (mapExpr f a)
+
+mapExpr f (BvnorExpr a b) = f $ BvnorExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvnotExpr a) = f $ BvnotExpr (mapExpr f a)
+
+mapExpr f (BvorExpr a b) = f $ BvorExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvrolExpr a b) = f $ BvrolExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvrorExpr a b) = f $ BvrorExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvsubExpr a b) = f $ BvsubExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvxnorExpr a b) = f $ BvxnorExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (BvxorExpr a b) = f $ BvxorExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (ConcatExpr a) = f $ ConcatExpr (map (mapExpr f) a)
+
+mapExpr f (EqualExpr a b) = f $ EqualExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (ExtractExpr l h e) = f $ ExtractExpr l h (mapExpr f e)
+
+mapExpr f (ReplaceExpr l a b) = f $ ReplaceExpr l (mapExpr f a) (mapExpr f b)
+
+mapExpr f (IteExpr a b c) = f $ IteExpr (mapExpr f a) (mapExpr f b) (mapExpr f c)
+
+mapExpr f (LandExpr a b) = f $ LandExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (LnotExpr a) = f $ LnotExpr (mapExpr f a)
+
+mapExpr f (LorExpr a b) = f $ LorExpr (mapExpr f a) (mapExpr f b)
+
+mapExpr f (ReferenceExpr a b) = f $ ReferenceExpr a b
+
+mapExpr f (SxExpr a b) = f $ SxExpr a (mapExpr f b)
+
+mapExpr f (ZxExpr a b) = f $ ZxExpr a (mapExpr f b)
+
+mapExpr f (UndefinedExpr a) = f $ UndefinedExpr a
+
+mapExpr f (Load a b) = f $ Load a (mapExpr f b)
+
+mapExpr f (GetReg a) = f $ GetReg a
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,6 +6,7 @@ import Hapstone.Internal.Capstone as Capstone
 import Ast
 import SymbolicEval
 import BitVector
+import Phasses
 
 import Lifter
 --import Simplify
@@ -22,7 +23,18 @@ main = do
   let lifted = case asm of
                   Left _ -> error "error on disasm"
                   Right b -> liftAsm modes b
-      oneblock = foldl (\y (a, b) -> y ++ b) [] lifted
+      oneblock = lifted
   -- print lifted
   -- print oneblock
-  print {-(getRegisterValues (reg_file (fst-} (symSteps (labelStmts lifted) (basicX86Context modes)){-)))-}
+  -- Label the statements produced by lifting from assembly. The labels are necessary for
+  -- the cross referencing that happens in the next stage.
+  let labelled = snd $ labelStmts 0 lifted
+  -- Simplify the labelled statements by doing constant propagation and folding, and by
+  -- introducing cross references
+  let simplified = snd $ symExec (basicX86Context modes) labelled
+  -- Elimate the dead code under the assumption that the flag bits are defined-before-use
+  -- in the fragment of code that follows simplified
+  let eliminated = snd $ eliminateDeadCode [(1408,1472)] simplified
+  -- Now print what we have.
+  print eliminated
+  --print {-(getRegisterValues (reg_file (fst-} (symExec (basicX86Context modes) (snd $ labelStmts 0 lifted)){-)))-}

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,6 +7,7 @@ import Ast
 import SymbolicEval
 import BitVector
 import Phasses
+import Data.Maybe
 
 import Lifter
 --import Simplify
@@ -26,15 +27,18 @@ main = do
       oneblock = lifted
   -- print lifted
   -- print oneblock
+  
   -- Label the statements produced by lifting from assembly. The labels are necessary for
   -- the cross referencing that happens in the next stage.
   let labelled = snd $ labelStmts 0 lifted
-  -- Simplify the labelled statements by doing constant propagation and folding, and by
-  -- introducing cross references
+  -- Simplify the labelled statements by doing constant propagation and folding.
   let simplified = snd $ symExec (basicX86Context modes) labelled
   -- Elimate the dead code under the assumption that the flag bits are defined-before-use
-  -- in the fragment of code that follows simplified
-  let eliminated = snd $ eliminateDeadCode [(1408,1472)] simplified
-  -- Now print what we have.
-  print eliminated
+  -- in the fragment of code that follows simplified. Wrap it in a statement.
+  let eliminated = Compound (-1) $ maybeToList $ snd $ eliminateDeadCode [(1408,1472)] simplified
+  -- Now introduce cross references into the statements. This must be done after dead code
+  -- elimination as it obscures the locations where expressions are loaded from storage.
+  let referenced = snd $ insertRefs (basicX86Context modes) eliminated
+  -- Now print the result of the above transformations.
+  print referenced
   --print {-(getRegisterValues (reg_file (fst-} (symExec (basicX86Context modes) (snd $ labelStmts 0 lifted)){-)))-}

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -1,6 +1,8 @@
 module Phasses where
 
 import Data.List
+import Ast
+import Data.Maybe
 
 data SG = Set Int Int | Get Int deriving (Show, Eq)
 
@@ -14,6 +16,45 @@ naive_dead_code_elimination =
               Set a _ -> cond_add a
               Get a -> ([ele] ++ acc1, nacc2_delete a)
   in  foldr folder ([], []) [Set 5 1, Set 1 1, Set 1 2, Get 2, Get 1, Get 3, Set 1 3]
+
+-- If a statement sets a particular register, then that register is added to the
+-- defined-before-use register list. If a statement accesses a particular register,
+-- then that register is removed from the defined-before-use register list.
+
+updateDefinedRegisters :: [CompoundReg] -> Stmt a -> [CompoundReg]
+
+updateDefinedRegisters regs (SetReg _ reg expr) =
+  let removeAccessedReg rs e = case e of
+        GetReg r -> removeRegister rs r
+        _ -> rs
+  in foldl removeAccessedReg (addRegister regs reg) (flatten expr)
+
+updateDefinedRegisters regs (Store _ _ expr) =
+  let removeAccessedReg rs e = case e of
+        GetReg r -> removeRegister rs r
+        _ -> rs
+  in foldl removeAccessedReg regs (flatten expr)
+
+updateDefinedRegisters regs (Compound _ stmts) =
+  foldl updateDefinedRegisters regs stmts
+
+-- Eliminates dead code by keeping track of the registers that are defined before use.
+-- First argument is the list of registers that have been defined before use in the
+-- fragment after the supplied statement. Second argument is the statement whose liveness
+-- needs to be determined. Returns the argument statement depending on whether or not it
+-- is dead. Also returns the list of registers that have been defined before use in the
+-- fragment beginning with the supplied statement.
+
+eliminateDeadCode :: [CompoundReg] -> Stmt a -> ([CompoundReg], Maybe (Stmt a))
+
+eliminateDeadCode regs (SetReg id reg expr) | isRegisterContained regs reg =
+  (updateDefinedRegisters regs (SetReg id reg expr), Nothing)
+
+eliminateDeadCode regs (Compound id stmts) =
+  let (finalRegs, newStmts) = mapAccumR eliminateDeadCode regs stmts
+  in (finalRegs, Just $ Compound id (catMaybes newStmts))
+
+eliminateDeadCode regs stmt = (updateDefinedRegisters regs stmt, Just stmt)
 
 {-
 fails on:

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -59,15 +59,6 @@ toStaticExpr exprVal id = case exprVal of
   -- Otherwise put in a reference to this expression
   a -> ReferenceExpr (getExprSize a) id
 
--- If the supplied expression is GetReg, then substitute it for its value. Otherwise leave
--- the expression unchanged.
-
-substituteReg :: SymExecutionContext -> Expr -> Expr
-
-substituteReg cin expr = case expr of
-  GetReg bs -> getRegisterValue (reg_file cin) bs
-  _ -> expr
-
 -- Symbolically executes the statement on the given context, potentially simplifying it in
 -- the process. Put the result of the simplification or a self-reference into storage.
 -- Returns resulting context.
@@ -75,13 +66,13 @@ substituteReg cin expr = case expr of
 insertRefs :: SymExecutionContext -> Stmt Int -> (SymExecutionContext, Stmt Int)
 
 insertRefs cin (SetReg id bs a) =
-  let exprVal = mapExpr (substituteReg cin) a
+  let exprVal = mapExpr (substituteStorage cin) a
       regVal = toStaticExpr exprVal id
   in (cin { reg_file = setRegisterValue (reg_file cin) bs regVal }, SetReg id bs exprVal)
 
 insertRefs cin (Store id dst val) =
-  let pdest = mapExpr (substituteReg cin) dst
-      pval = mapExpr (substituteReg cin) val
+  let pdest = mapExpr (substituteStorage cin) dst
+      pval = mapExpr (substituteStorage cin) val
       memVal = toStaticExpr pval id
   in
       case pdest of

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -227,7 +227,7 @@ substituteSimplify :: SymExecutionContext -> Expr -> Expr
 
 substituteSimplify cin expr =
   let nextExpr = simplifyExpr $ mapExpr (substituteStorage cin) expr
-  in if nextExpr == expr then nextExpr else {-substituteSimplify cin-} nextExpr
+  in if nextExpr == expr then nextExpr else substituteSimplify cin nextExpr
 
 -- Put the given expression into memory starting at the given address and return the new
 -- context.


### PR DESCRIPTION
Implemented the naive dead code elimination algorithm. Also implemented simplification of expressions loaded from separate slots of memory. An example of the transformations it performs is as follows:
```
mov    esp,0x64
push   eax
mov    eax,0x2
add    eax,0xa
pop    eax
sub    eax,0x3
```
TO
```
SetReg 6 (448,480) (BvExpr ([96],32))
Store 7 (BvExpr ([96],32)) (ZxExpr 0 (GetReg (0,32)))
SetReg 22 (0,32) (ReferenceExpr 32 7)
SetReg 23 (448,480) (BvExpr ([100],32))
SetReg 25 (1472,1504) (BvExpr ([18],32))
SetReg 26 (0,32) (BvsubExpr (ReferenceExpr 32 7) (BvExpr ([3],32)))
```