### PR TITLE
Simplify simplify expr

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -277,9 +277,9 @@ data Expr =
   | ZxExpr Int Expr
   -- An undefined expression of the given size.
   | UndefinedExpr Int
-  -- Takes in order the number of bytes to extract from memory, and the address in memory
-  -- from which to obtain data. Size of this expression equals the number of bits to be
-  -- extracted from memory.
+  -- Takes in order the number of bits to extract from memory, and the byte address in
+  -- memory from which to obtain data. Size of this expression equals the number of bits
+  -- to be extracted from memory.
   | Load Int Expr
   -- Obtains the value of the given register. The size of this expression equals the size,
   -- in bits, of the register.
@@ -375,7 +375,7 @@ getExprSize (ZxExpr a b) = a + getExprSize b
 
 getExprSize (UndefinedExpr a) = a
 
-getExprSize (Load a b) = a * byte_size_bit
+getExprSize (Load a b) = a
 
 getExprSize (GetReg a) = getRegisterSize a
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -369,7 +369,7 @@ getExprSize (LorExpr a b) = getExprSize a
 
 getExprSize (ReferenceExpr a b) = a
 
-getExprSize (SxExpr a b) = a + getExprSize b
+getExprSize (SxExpr a b) = a
 
 getExprSize (ZxExpr a b) = a
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -269,11 +269,11 @@ data Expr =
   -- identifier of the expression being referenced. Size of this expression equals the
   -- size of the expression being referenced.
   | ReferenceExpr Int Int
-  -- Sign extends the given expression by the given amount. Size of this expression equals
-  -- the sum of the given amount and the size of the given expression.
+  -- Sign extends the given expression to the given size. Size of this expression equals
+  -- the given amount.
   | SxExpr Int Expr
-  -- Zero extends the given expression by the given amount. Size of this expression equals
-  -- the sum of the given amount and the size of the given expression.
+  -- Zero extends the given expression to the given size. Size of this expression equals
+  -- the given amount.
   | ZxExpr Int Expr
   -- An undefined expression of the given size.
   | UndefinedExpr Int
@@ -371,7 +371,7 @@ getExprSize (ReferenceExpr a b) = a
 
 getExprSize (SxExpr a b) = a + getExprSize b
 
-getExprSize (ZxExpr a b) = a + getExprSize b
+getExprSize (ZxExpr a b) = a
 
 getExprSize (UndefinedExpr a) = a
 

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -309,6 +309,11 @@ data Stmt a =
   -- Takes in order the id of the statement, and an ordered list of statements that will
   -- be executed when this statement is executed.
   | Compound a [Stmt a]
+  -- An inert statement where the String argument is the actual comment. Some conditions
+  -- that may cause the generation of this constructor are invalid object code and
+  -- usage of unsupported instructions. Comment statements are used to ensure the
+  -- successful code analysis even in the presence of hostile program inputs.
+  | Comment String
   deriving (Eq, Show)
 
 -- The size of an expression can be determined statically directly from it and its

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -137,7 +137,7 @@ eval cin (GetReg bs) =
 
 eval cin (Load a b) =
   let memStart = bvToInt (eval cin b)
-      memVal = getMemoryValue (memory cin) [memStart..(memStart + a - 1)]
+      memVal = getMemoryValue (memory cin) [memStart..(memStart + (div a byte_size_bit) - 1)]
   in case memVal of
     Nothing -> error "Read attempted on uninitialized memory."
     Just x -> x

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -27,7 +27,7 @@ mmp modes a = Compound (Just $ convert (address a)) ((case toEnum (fromIntegral 
   X86InsJe -> je_s
   X86InsLea -> lea_s
   X86InsInc -> inc_s
-  otherwise -> error ("Instruction " ++ mnemonic a ++ " not supported.")) modes a)
+  _ -> \_ _ -> [Comment ("Instruction " ++ mnemonic a ++ " not supported. Ignoring opcode.")]) modes a)
 
 liftAsm :: [CsMode] -> [CsInsn] -> Stmt (Maybe Int)
 

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -15,7 +15,7 @@ mmp :: [CsMode] -> CsInsn -> Stmt (Maybe Int)
 mmp modes a = Compound (Just $ convert (address a)) ((case toEnum (fromIntegral (insnId a)) of
   X86InsAdd -> add_s
   X86InsMov -> mov_s
-  X86InsMovzx -> mov_s --will this trigger bits missaling?
+  X86InsMovzx -> movzx_s
   X86InsSub -> sub_s
   X86InsCmp -> cmp_s
   X86InsPush -> push_s

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -77,7 +77,9 @@ insertRefs cin (Store id dst val) =
   in
       case pdest of
         BvExpr a -> (updateMemory cin (bvToInt a) memVal, Store id pdest pval)
-        _ -> error "Store on symbolic mem not implemented"
+        _ -> (cin, Comment "Store on symbolic memory not implemented. Ignoring statement.")
+
+insertRefs cin (Comment str) = (cin, Comment str)
 
 insertRefs cin (Compound id stmts) = (i, Compound id s)
   where (i,s) = mapAccumL insertRefs cin stmts

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -66,13 +66,13 @@ toStaticExpr exprVal id = case exprVal of
 insertRefs :: SymExecutionContext -> Stmt Int -> (SymExecutionContext, Stmt Int)
 
 insertRefs cin (SetReg id bs a) =
-  let exprVal = mapExpr (substituteStorage cin) a
+  let exprVal = mapExpr (substituteSimplify cin) a
       regVal = toStaticExpr exprVal id
   in (cin { reg_file = setRegisterValue (reg_file cin) bs regVal }, SetReg id bs exprVal)
 
 insertRefs cin (Store id dst val) =
-  let pdest = mapExpr (substituteStorage cin) dst
-      pval = mapExpr (substituteStorage cin) val
+  let pdest = mapExpr (substituteSimplify cin) dst
+      pval = mapExpr (substituteSimplify cin) val
       memVal = toStaticExpr pval id
   in
       case pdest of

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -220,7 +220,9 @@ symExec cin (Store id dst val) =
   in
       case pdest of
         BvExpr a -> (updateMemory cin (bvToInt a) memVal, Store id pdest pval)
-        _ -> error "Store on symbolic mem not implemented"
+        _ -> (cin, Comment "Store on symbolic memory not implemented. Ignoring statement.")
+
+symExec cin (Comment str) = (cin, Comment str)
 
 symExec cin (Compound id stmts) = (i, Compound id s)
   where (i,s) = mapAccumL symExec cin stmts
@@ -232,6 +234,8 @@ labelStmts :: Int -> Stmt a -> (Int, Stmt Int)
 labelStmts start (SetReg id bs a) = (start + 1, SetReg start bs a)
 
 labelStmts start (Store id dst val) = (start + 1, Store start dst val)
+-- Comments cannot be referenced, hence they do not need labels
+labelStmts start (Comment str) = (start, Comment str)
 
 labelStmts start (Compound id stmts) = (i, Compound start s)
   where (i,s) = mapAccumL labelStmts (start + 1) stmts

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -130,7 +130,6 @@ simplifyExprAux (BvlshrExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvlshr abv bbv)
 simplifyExprAux (ZxExpr a (BvExpr bbv)) = BvExpr (zx a bbv)
 
 simplifyExprAux (IteExpr (BvExpr a) b c) = if equal a (zero a) then c else b
-
 -- The entire expression is being replaced
 simplifyExprAux (ReplaceExpr l a b) | getExprSize a == getExprSize b = b
 -- Join together two adjacent replacements
@@ -142,7 +141,6 @@ simplifyExprAux (ReplaceExpr l (BvExpr a) (BvExpr b)) = BvExpr $ bvreplace a l b
 -- The current replacement coincides with a previous replacement
 simplifyExprAux (ReplaceExpr l (ReplaceExpr a b c) e) | l == a && getExprSize e == getExprSize c =
   ReplaceExpr l b e
-
 -- The extraction is the entire expression
 simplifyExprAux (ExtractExpr l h e) | h - l == getExprSize e = e
 -- The extraction is being done on a literal

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -234,7 +234,7 @@ cmp_s :: [CsMode] -> CsInsn -> [Stmt (Maybe a)]
 cmp_s modes inst =
   let (dst : src : _ ) = x86operands inst
       dst_ast = getOperandAst modes dst
-      src_ast = SxExpr (convert ((size dst) - (size src)) * 8) (getOperandAst modes src)
+      src_ast = SxExpr (convert (size dst) * byte_size_bit) (getOperandAst modes src)
       cmp_node = BvsubExpr dst_ast src_ast
   in [
       inc_insn_ptr modes inst,

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -400,6 +400,20 @@ mov_s modes inst =
         SetReg Nothing (fromX86Flag X86FlagCf) (UndefinedExpr 1),
         SetReg Nothing (fromX86Flag X86FlagOf) (UndefinedExpr 1)]
 
+-- Make list of operations in the IR that has the same semantics as the X86 movzx instruction
+
+movzx_s :: [CsMode] -> CsInsn -> [Stmt (Maybe a)]
+
+movzx_s modes inst =
+  let (dst_op : src_op : _ ) = x86operands inst
+      dst_ast = getOperandAst modes dst_op
+      src_ast = getOperandAst modes src_op
+      dst_size_bit = (convert $ size dst_op) * 8
+      src_size_bit = (convert $ size src_op) * 8
+      zx_node = ZxExpr (dst_size_bit - src_size_bit) src_ast
+  in
+    [inc_insn_ptr modes inst,
+    store_stmt modes dst_op zx_node]
 
 -- Make a list of operations in the IR that has the same semantics as the X86 jmp instruction
 


### PR DESCRIPTION
Separated expression transformations from tree walking algorithm. Implemented `MOVZX` semantics. Program no longer fails on error - instead it uses a comment node. Modified ZxExpr and SxExpr to take target size. `Load` now takes bit instead of byte size.