### PR TITLE
Tranformation tests

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -13,20 +13,19 @@ import Data.Maybe
 import Control.Monad.State.Lazy
 import Data.Coerce
 import Data.Functor.Identity
-import Debug.Trace
 
-byte_size_bit :: Num a => a
-byte_size_bit = 8
-word_size_bit :: Num a => a
-word_size_bit = 16
-dword_size_bit = 32
-qword_size_bit = 64
-dqword_size_bit = 128
-qqword_size_bit = 256
-dqqword_size_bit = 512
+byteSizeBit :: Num a => a
+byteSizeBit = 8
+wordSizeBit :: Num a => a
+wordSizeBit = 16
+dWordSizeBit = 32
+qWordSizeBit = 64
+dqWordSizeBit = 128
+qqWordSizeBit = 256
+dqqWordSizeBit = 512
 
-reg_file_bits :: Num a => a
-reg_file_bits = 192 * byte_size_bit
+regFileBits :: Num a => a
+regFileBits = 192 * byteSizeBit
 
 data X86Flag =
     X86FlagCf | X86FlagPf | X86FlagAf | X86FlagZf | X86FlagSf | X86FlagTf | X86FlagIf
@@ -83,7 +82,7 @@ x86RegisterMap = [
 
 -- EFLAGS Register
 
-  {-,(X86RegEflags, b(176,184))-}] where b(l,h) = (l*byte_size_bit,h*byte_size_bit)
+  {-,(X86RegEflags, b(176,184))-}] where b(l,h) = (l*byteSizeBit,h*byteSizeBit)
 
 -- Convert an X86Reg to a CompoundReg
 
@@ -104,7 +103,7 @@ x86FlagMap = [(X86FlagCf, c(176,0,1)), (X86FlagPf, c(176,2,3)),
   (X86FlagRf, c(176,16,17)), (X86FlagVm, c(176,17,18)), (X86FlagAc, c(176,18,19)),
   (X86FlagVif, c(176,19,20)), (X86FlagVip, c(176,20,21)), (X86FlagId, c(176,21,22))]
   
-  where c(b,l,h) = (b*byte_size_bit+l,b*byte_size_bit+h)
+  where c(b,l,h) = (b*byteSizeBit+l,b*byteSizeBit+h)
 
 -- Convert an X86Reg to a CompoundReg
 
@@ -152,7 +151,7 @@ getArchByteSize modes =
 
 getArchBitSize :: [CsMode] -> Int
 
-getArchBitSize = (* byte_size_bit) . getArchByteSize
+getArchBitSize = (* byteSizeBit) . getArchByteSize
 
 -- Adds the given register to the given list taking care to combine those that overlap
 
@@ -710,18 +709,18 @@ exprToSVal (Load 0 _) = exprToSVal (BvExpr (bvzero 0))
 exprToSVal (Load a b) = do
   exprValAssocs <- get
   let (exprs, svals) = unzip exprValAssocs
-  results <- mapM proveRelation $ map (EqualExpr (Load byte_size_bit b)) exprs
+  results <- mapM proveRelation $ map (EqualExpr (Load byteSizeBit b)) exprs
   if elem Nothing results then
     fail "Could not determine the equality of two expressions."
   else if not $ elem (Just True) results then do
-    let newExpr = Load byte_size_bit b
-    newVar <- sWordN_ byte_size_bit
+    let newExpr = Load byteSizeBit b
+    newVar <- sWordN_ byteSizeBit
     put ((newExpr, newVar) : exprValAssocs)
     exprToSVal (Load a b)
   else do
     let boolValAssocs = zip results svals
         val = fromJust $ lookup (Just True) boolValAssocs
-    rest <- exprToSVal (Load (a - byte_size_bit) (BvaddExpr b (BvExpr $ bvone (getExprSize b))))
+    rest <- exprToSVal (Load (a - byteSizeBit) (BvaddExpr b (BvExpr $ bvone (getExprSize b))))
     return $ svJoin val rest
 
 -- Turn a GetReg into an SVal by looking up the corresponding SVal in the current

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -400,79 +400,92 @@ getExprSize (Load a b) = a
 
 getExprSize (GetReg a) = getRegisterSize a
 
+-- Creates a post-ordered list of statements from the given statement. Sometimes the
+-- hierarchy is a hindrance in computations.
+
+flattenStmt :: Stmt a b c d -> [Stmt a b c d]
+
+flattenStmt (Store a b c) = [Store a b c]
+
+flattenStmt (SetReg a b c) = [SetReg a b c]
+
+flattenStmt (Compound a b) = (concat $ map flattenStmt b) ++ [Compound a b]
+
+flattenStmt (Comment a b) = [Comment a b]
+
 -- Creates a post-ordered list of expressions from the given expression. Sometimes the
 -- hierarchy is a hindrance in computations.
 
-flatten :: Expr -> [Expr]
+flattenExpr :: Expr -> [Expr]
 
-flatten (BvExpr bv) = [(BvExpr bv)]
+flattenExpr (BvExpr bv) = [(BvExpr bv)]
 
-flatten (BvmulExpr a b) = flatten a ++ flatten b ++ [BvmulExpr a b]
+flattenExpr (BvmulExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvmulExpr a b]
 
-flatten (BvudivExpr a b) = flatten a ++ flatten b ++ [BvudivExpr a b]
+flattenExpr (BvudivExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvudivExpr a b]
 
-flatten (BvsdivExpr a b) = flatten a ++ flatten b ++ [BvsdivExpr a b]
+flattenExpr (BvsdivExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvsdivExpr a b]
 
-flatten (BvugtExpr a b) = flatten a ++ flatten b ++ [BvugtExpr a b]
+flattenExpr (BvugtExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvugtExpr a b]
 
-flatten (BvultExpr a b) = flatten a ++ flatten b ++ [BvultExpr a b]
+flattenExpr (BvultExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvultExpr a b]
 
-flatten (BvugeExpr a b) = flatten a ++ flatten b ++ [BvugeExpr a b]
+flattenExpr (BvugeExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvugeExpr a b]
 
-flatten (BvuleExpr a b) = flatten a ++ flatten b ++ [BvuleExpr a b]
+flattenExpr (BvuleExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvuleExpr a b]
 
-flatten (BvsgtExpr a b) = flatten a ++ flatten b ++ [BvsgtExpr a b]
+flattenExpr (BvsgtExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvsgtExpr a b]
 
-flatten (BvsltExpr a b) = flatten a ++ flatten b ++ [BvsltExpr a b]
+flattenExpr (BvsltExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvsltExpr a b]
 
-flatten (BvsgeExpr a b) = flatten a ++ flatten b ++ [BvsgeExpr a b]
+flattenExpr (BvsgeExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvsgeExpr a b]
 
-flatten (BvsleExpr a b) = flatten a ++ flatten b ++ [BvsleExpr a b]
+flattenExpr (BvsleExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvsleExpr a b]
 
-flatten (BvaddExpr a b) = flatten a ++ flatten b ++ [BvaddExpr a b]
+flattenExpr (BvaddExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvaddExpr a b]
 
-flatten (BvandExpr a b) = flatten a ++ flatten b ++ [BvandExpr a b]
+flattenExpr (BvandExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvandExpr a b]
 
-flatten (BvashrExpr a b) = flatten a ++ flatten b ++ [BvashrExpr a b]
+flattenExpr (BvashrExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvashrExpr a b]
 
-flatten (BvlshrExpr a b) = flatten a ++ flatten b ++ [BvlshrExpr a b]
+flattenExpr (BvlshrExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvlshrExpr a b]
 
-flatten (BvnegExpr a) = flatten a ++ [BvnegExpr a]
+flattenExpr (BvnegExpr a) = flattenExpr a ++ [BvnegExpr a]
 
-flatten (BvnotExpr a) = flatten a ++ [BvnotExpr a]
+flattenExpr (BvnotExpr a) = flattenExpr a ++ [BvnotExpr a]
 
-flatten (BvorExpr a b) = flatten a ++ flatten b ++ [BvorExpr a b]
+flattenExpr (BvorExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvorExpr a b]
 
-flatten (BvrolExpr a b) = flatten a ++ flatten b ++ [BvrolExpr a b]
+flattenExpr (BvrolExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvrolExpr a b]
 
-flatten (BvrorExpr a b) = flatten a ++ flatten b ++ [BvrorExpr a b]
+flattenExpr (BvrorExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvrorExpr a b]
 
-flatten (BvsubExpr a b) = flatten a ++ flatten b ++ [BvsubExpr a b]
+flattenExpr (BvsubExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvsubExpr a b]
 
-flatten (BvxorExpr a b) = flatten a ++ flatten b ++ [BvxorExpr a b]
+flattenExpr (BvxorExpr a b) = flattenExpr a ++ flattenExpr b ++ [BvxorExpr a b]
 
-flatten (ConcatExpr a) = foldl (++) [] (map flatten a) ++ [ConcatExpr a]
+flattenExpr (ConcatExpr a) = foldl (++) [] (map flattenExpr a) ++ [ConcatExpr a]
 
-flatten (EqualExpr a b) = flatten a ++ flatten b ++ [EqualExpr a b]
+flattenExpr (EqualExpr a b) = flattenExpr a ++ flattenExpr b ++ [EqualExpr a b]
 
-flatten (ExtractExpr l h e) = flatten e ++ [ExtractExpr l h e]
+flattenExpr (ExtractExpr l h e) = flattenExpr e ++ [ExtractExpr l h e]
 
-flatten (ReplaceExpr l a b) = flatten a ++ flatten b ++ [ReplaceExpr l a b]
+flattenExpr (ReplaceExpr l a b) = flattenExpr a ++ flattenExpr b ++ [ReplaceExpr l a b]
 
-flatten (IteExpr a b c) = flatten a ++ flatten b ++ flatten c ++ [IteExpr a b c]
+flattenExpr (IteExpr a b c) = flattenExpr a ++ flattenExpr b ++ flattenExpr c ++ [IteExpr a b c]
 
-flatten (ReferenceExpr a b) = [ReferenceExpr a b]
+flattenExpr (ReferenceExpr a b) = [ReferenceExpr a b]
 
-flatten (SxExpr a b) = flatten b ++ [SxExpr a b]
+flattenExpr (SxExpr a b) = flattenExpr b ++ [SxExpr a b]
 
-flatten (ZxExpr a b) = flatten b ++ [ZxExpr a b]
+flattenExpr (ZxExpr a b) = flattenExpr b ++ [ZxExpr a b]
 
-flatten (UndefinedExpr a) = [UndefinedExpr a]
+flattenExpr (UndefinedExpr a) = [UndefinedExpr a]
 -- Does not recur into b. This is in order to be consistent with mapMExpr and exprToSVal
 -- which also do not recur into b.
-flatten (Load a b) = [Load a b]
+flattenExpr (Load a b) = [Load a b]
 
-flatten (GetReg a) = [GetReg a]
+flattenExpr (GetReg a) = [GetReg a]
 
 -- Going through the expression tree in post-order, monadically map expressions to other
 -- expressions using the given function.

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -122,9 +122,9 @@ getRegisterSize (l, h) = h - l
 
 -- Gets the stack register for the given processor mode
 
-get_stack_reg :: [CsMode] -> CompoundReg
+getStackReg :: [CsMode] -> CompoundReg
 
-get_stack_reg modes =
+getStackReg modes =
   if elem CsMode16 modes then fromX86Reg X86RegSp
   else if elem CsMode32 modes then fromX86Reg X86RegEsp
   else if elem CsMode64 modes then fromX86Reg X86RegRsp
@@ -132,9 +132,9 @@ get_stack_reg modes =
 
 -- Gets the instruction pointer for the given processor mode
 
-get_insn_ptr :: [CsMode] -> CompoundReg
+getInsnPtr :: [CsMode] -> CompoundReg
 
-get_insn_ptr modes =
+getInsnPtr modes =
   if elem CsMode16 modes then fromX86Reg X86RegIp
   else if elem CsMode32 modes then fromX86Reg X86RegEip
   else if elem CsMode64 modes then fromX86Reg X86RegRip
@@ -142,17 +142,17 @@ get_insn_ptr modes =
 
 -- Gets the architecture size for the given processor mode
 
-get_arch_byte_size :: [CsMode] -> Int
+getArchByteSize :: [CsMode] -> Int
 
-get_arch_byte_size modes =
+getArchByteSize modes =
   if elem CsMode16 modes then 2
   else if elem CsMode32 modes then 4
   else if elem CsMode64 modes then 8
   else error "Processor modes underspecified."
 
-get_arch_bit_size :: [CsMode] -> Int
+getArchBitSize :: [CsMode] -> Int
 
-get_arch_bit_size = (* byte_size_bit) . get_arch_byte_size
+getArchBitSize = (* byte_size_bit) . getArchByteSize
 
 -- Adds the given register to the given list taking care to combine those that overlap
 
@@ -208,15 +208,15 @@ registerSub (l1, h1) (l2, h2) = (l1-l2, h1-l2)
 
 -- Checks if the given register is a segment register
 
-is_segment_reg :: X86.X86Reg -> Bool
+isSegmentReg :: X86.X86Reg -> Bool
 
-is_segment_reg reg = elem reg [X86RegCs, X86RegDs, X86RegSs, X86RegEs, X86RegFs, X86RegGs]
+isSegmentReg reg = elem reg [X86RegCs, X86RegDs, X86RegSs, X86RegEs, X86RegFs, X86RegGs]
 
 -- Checks if the given register is a control register
 
-is_control_reg :: X86.X86Reg -> Bool
+isControlReg :: X86.X86Reg -> Bool
 
-is_control_reg reg = elem reg
+isControlReg reg = elem reg
   [X86RegCr0, X86RegCr1, X86RegCr2, X86RegCr3, X86RegCr4, X86RegCr5, X86RegCr6,
   X86RegCr7, X86RegCr8, X86RegCr9, X86RegCr10, X86RegCr11, X86RegCr12, X86RegCr13,
   X86RegCr14, X86RegCr15]
@@ -734,11 +734,10 @@ exprToSVal (GetReg a) = do
 
 exprToSVal (UndefinedExpr a) = sWordN_ a
 
--- Checks if two expressions are equal using an SMT solver. Returns Just True after I/O if
--- SMT solver is able to prove that expressions are equal for all variable assignments.
--- Returns Just False after I/O if SMT solver is able to prove that expressions are
--- unequal for all variable assignments. Returns Nothing after I/O is SMT solver is not
--- able to prove either.
+-- Checks the given relation using an SMT solver. Returns Just True after I/O if SMT
+-- solver is able to prove the relation for all variable assignments. Returns Just False
+-- after I/O if SMT solver is able to prove the negation of the relation for all variable
+-- assignments. Returns Nothing after I/O is SMT solver is not able to prove either.
 
 proveRelation :: MonadIO m => Expr -> m (Maybe Bool)
 

--- a/src/BitVector.hs
+++ b/src/BitVector.hs
@@ -8,19 +8,19 @@ import Numeric.Natural
 -- Second item of tuple is bit-vector size in bits. The bit-vector must have length equal
 -- to ceil(size/digitBitSize).
 
-type BitVector = (Integer, Int)
+newtype BitVector = Bv (Integer, Int) deriving Show
 
 bvlength :: BitVector -> Int
 
-bvlength (av,an) = an
+bvlength (Bv (av, an)) = an
 
 bvtrue :: BitVector
 
-bvtrue = (1,1)
+bvtrue = Bv (1, 1)
 
 bvfalse :: BitVector
 
-bvfalse = (0,1)
+bvfalse = Bv (0, 1)
 
 boolToBv :: Bool -> BitVector
 
@@ -30,95 +30,65 @@ boolToBv False = bvfalse
 
 empty :: BitVector
 
-empty = (0, 0)
+empty = Bv (0, 0)
 
 bvzero :: Int -> BitVector
 
-bvzero a = (0,a)
+bvzero a = Bv (0, a)
 
 bvone :: Int -> BitVector
 
-bvone a = (1,a)
+bvone a = Bv (1, a)
 
 bvxor :: BitVector -> BitVector -> BitVector
 
-bvxor (av,an) (bv,bn) | an == bn = (xor av bv, an)
+bvxor (Bv (av,an)) (Bv (bv,bn)) | an == bn = Bv (xor av bv, an)
 
 bvxor _ _ = error "Bit-vector arguments to BvxorExpr have different bit-lengths."
 
 bvand :: BitVector -> BitVector -> BitVector
 
-bvand (av,an) (bv,bn) | an == bn = (av .&. bv, an)
+bvand (Bv (av,an)) (Bv (bv,bn)) | an == bn = Bv (av .&. bv, an)
 
 bvand _ _ = error "Bit-vector arguments to BvandExpr have different bit-lengths."
 
 bvor :: BitVector -> BitVector -> BitVector
 
-bvor (av,an) (bv,bn) | an == bn = (av .|. bv, an)
+bvor (Bv (av,an)) (Bv (bv,bn)) | an == bn = Bv (av .|. bv, an)
 
 bvor _ _ = error "Bit-vector arguments to BvorExpr have different bit-lengths."
 
 bvnot :: BitVector -> BitVector
 
-bvnot (av,an) = (complement av, an)
+bvnot (Bv (av,an)) = Bv (complement av, an)
 
 -- Zero extends the given bit-vector to the given amount
 
 zx :: Int -> BitVector -> BitVector
 
-zx a b = (fromBvU b, a)
+zx a b = Bv (fromBvU b, a)
 
 -- Gets the given bit of the bit-vector
 
 bvbit :: BitVector -> Int -> Bool
 
-bvbit (bv,bn) idx = testBit bv idx
+bvbit (Bv (bv, bn)) idx = testBit bv idx
 
 -- Sign extends the given bit-vector to the given amount
 
 sx :: Int -> BitVector -> BitVector
 
-sx a b = (fromBvS b, a)
-
--- Compares two bit-vectors by zero-extending both and element-wise checking word equality
-
-bvequal :: BitVector -> BitVector -> Bool
-
-bvequal a b | bvlength a == bvlength b = fromBvU a == fromBvU b
-
-bvequal _ _ = error "Bit-vector arguments to EqualExpr have different bit-lengths."
-
-bvadd :: BitVector -> BitVector -> BitVector
-
-bvadd (av,an) (bv,bn) | an == bn = (av+bv, an)
-
-bvadd _ _ = error "Bit-vector arguments to BvaddExpr have different bit-lengths."
-
-bvnegate :: BitVector -> BitVector
-
-bvnegate (av,an) = (-av, an)
-
-bvsub :: BitVector -> BitVector -> BitVector
-
-bvsub (av,an) (bv,bn) | an == bn = (av-bv, an)
-
-bvsub _ _ = error "Bit-vector arguments to BvsubExpr have different bit-lengths."
-
-bvmul :: BitVector -> BitVector -> BitVector
-
-bvmul (av,an) (bv,bn) | an == bn = (av*bv,an)
-
-bvmul _ _ = error "Bit-vector arguments to BvmulExpr have different bit-lengths."
+sx a b = Bv (fromBvS b, a)
 
 bvudiv :: BitVector -> BitVector -> BitVector
 
-bvudiv a b | bvlength a == bvlength b = (div (fromBvU a) (fromBvU b), bvlength a)
+bvudiv a b | bvlength a == bvlength b = Bv (div (fromBvU a) (fromBvU b), bvlength a)
 
 bvudiv _ _ = error "Bit-vector arguments to BvudivExpr have different bit-lengths."
 
 bvsdiv :: BitVector -> BitVector -> BitVector
 
-bvsdiv a b | bvlength a == bvlength b = (div (fromBvS a) (fromBvS b), bvlength a)
+bvsdiv a b | bvlength a == bvlength b = Bv (div (fromBvS a) (fromBvS b), bvlength a)
 
 bvsdiv _ _ = error "Bit-vector arguments to BvsdivExpr have different bit-lengths."
 
@@ -172,24 +142,24 @@ ite a b c = if fromBvU a == 1 then b else c
 
 bvlshr :: BitVector -> BitVector -> BitVector
 
-bvlshr a b = (shiftR (fromBvU a) (fromBvU b), bvlength a)
+bvlshr a b = Bv (shiftR (fromBvU a) (fromBvU b), bvlength a)
 
 bvashr :: BitVector -> BitVector -> BitVector
 
-bvashr a b = (shiftR (fromBvS a) (fromBvU b), bvlength a)
+bvashr a b = Bv (shiftR (fromBvS a) (fromBvU b), bvlength a)
 
 bvshl :: BitVector -> BitVector -> BitVector
 
-bvshl a b = (shiftL (fromBvU a) (fromBvU b), bvlength a)
+bvshl a b = Bv (shiftL (fromBvU a) (fromBvU b), bvlength a)
 
 bvconcat :: BitVector -> BitVector -> BitVector
 
-bvconcat a b = bvor (bvshl (zx newlength a) (toInteger $ bvlength b, newlength)) (zx newlength b)
+bvconcat a b = bvor (bvshl (zx newlength a) (Bv (toInteger $ bvlength b, newlength))) (zx newlength b)
   where newlength = bvlength a + bvlength b
 
 bvextract :: Int -> Int -> BitVector -> BitVector
 
-bvextract l h a = zx (h - l) (bvlshr a (toInteger l, bvlength a))
+bvextract l h a = zx (h - l) (bvlshr a (Bv (toInteger l, bvlength a)))
 
 bvreplace :: BitVector -> Int -> BitVector -> BitVector
 
@@ -197,13 +167,37 @@ bvreplace a b c = bvconcat (bvextract (b + bvlength c) (bvlength a) a) (bvconcat
 
 fromBvU :: Num a => BitVector -> a
 
-fromBvU (av,an) = fromInteger ((bit an - 1) .&. av)
+fromBvU (Bv (av,an)) = fromInteger ((bit an - 1) .&. av)
 
 fromBvS :: Num a => BitVector -> a
 
-fromBvS (av,an) = fromInteger (if testBit av (an-1) then (-(bit an)) .|. av else (bit an - 1) .&. av)
+fromBvS (Bv (av,an)) = fromInteger (if testBit av (an-1) then (-(bit an)) .|. av else (bit an - 1) .&. av)
 
 toBv :: Integral a => a -> Int -> BitVector
 
-toBv a b = (toInteger a, b)
+toBv a b = Bv (toInteger a, b)
+
+-- The following instances are required to enable pattern matching on bit-vectors
+
+instance Num BitVector where
+  Bv (av,an) + Bv (bv,bn) | an == bn = Bv (av+bv, an)
+  _ + _ = error "Bit-vector arguments to BvaddExpr have different bit-lengths."
+  Bv (av,an) - Bv (bv,bn) | an == bn = Bv (av-bv, an)
+  _ - _ = error "Bit-vector arguments to BvsubExpr have different bit-lengths."
+  Bv (av,an) * Bv (bv,bn) | an == bn = Bv (av*bv,an)
+  _ * _ = error "Bit-vector arguments to BvmulExpr have different bit-lengths."
+  negate (Bv (av, an)) = Bv (-av, an)
+  abs (Bv (av, an)) = Bv (abs av, an)
+  signum (Bv (av, an)) = Bv (signum av, an)
+  -- A hack to enable pattern matching on BitVectors: -1 stands for variable length
+  fromInteger x = Bv (x, -1)
+
+instance Eq BitVector where
+  -- Comparing a fixed length bit-vector to a variable length bit-vector
+  a == Bv (b,-1) = Bv (b,-1) == a
+  Bv (a,-1) == b = Bv (a, bvlength b) == b
+  -- Comparing two bit-vectors that are fixed to the same length
+  a == b | bvlength a == bvlength b = fromBvU a == fromBvU b
+  -- Otherwise the two bit-vectors cannot be compared
+  _ == _ = error "Bit-vector arguments to EqualExpr have different bit-lengths."
 

--- a/src/EvalAst.hs
+++ b/src/EvalAst.hs
@@ -77,7 +77,7 @@ getMemoryValue _ _ 0 = Just empty
 
 getMemoryValue mem a exprSize =
   let nextAddr = a + toBv 1 (bvlength a)
-      nextSize = exprSize - byte_size_bit
+      nextSize = exprSize - byteSizeBit
   in case (lookupBv a mem, getMemoryValue mem nextAddr nextSize) of
     (Just x, Just y) -> Just (bvconcat y x)
     _ -> Nothing
@@ -89,9 +89,9 @@ updateMemory :: [(BitVector, BitVector)] -> BitVector -> BitVector -> [(BitVecto
 updateMemory mem _ v | bvlength v == 0 = mem
 
 updateMemory mem d v =
-  let nextBv = bvextract byte_size_bit (bvlength v) v
+  let nextBv = bvextract byteSizeBit (bvlength v) v
       nextAddr = d + toBv 1 (bvlength d)
-      currentVal = bvextract 0 byte_size_bit v
+      currentVal = bvextract 0 byteSizeBit v
   in updateMemory (assign mem (d, currentVal)) nextAddr nextBv
 
 -- Represents the state of a processor: register file contents, data memory contents, and

--- a/src/Lifter.hs
+++ b/src/Lifter.hs
@@ -12,30 +12,6 @@ import SymbolicEval
 import Phasses
 import Data.Maybe
 
---x86 vs arm, etc?
-mmp :: [CsMode] -> CsInsn -> IdStmt
-
-mmp modes a = (case toEnum (fromIntegral (insnId a)) of
-  X86InsAdd -> add_s
-  X86InsMov -> mov_s
-  X86InsMovzx -> movzx_s
-  X86InsSub -> sub_s
-  X86InsCmp -> cmp_s
-  X86InsPush -> push_s
-  X86InsPop -> pop_s
-  X86InsXor -> xor_s
-  X86InsAnd -> and_s
-  X86InsOr -> or_s
-  X86InsJmp -> jmp_s
-  X86InsJe -> je_s
-  X86InsJne -> jne_s
-  X86InsLea -> lea_s
-  X86InsInc -> inc_s
-  X86InsCall -> call_s
-  X86InsRet -> ret_s
-  X86InsTest -> test_s
-  _ -> \_ _ -> Comment (fromIntegral (address a)) ("Instruction " ++ mnemonic a ++ " not supported. Ignoring opcode.")) modes a
-
 -- Takes the processor mode and the executable code. Returns an ordered list of IdStmts
 -- such that for each instruction, there is exactly one IdStmt with the same semantics and
 -- an id equal to the address of the instruction.
@@ -44,9 +20,9 @@ lift :: [CsMode] -> [Word8] -> IO [IdStmt]
 
 lift modes input = do
   asm <- disasmSimpleIO $ disasm modes input 0
-  return (case asm of
+  return $ case asm of
     Left _ -> error "Error in disassembling machine code."
-    Right csInsns -> map (mmp modes) csInsns)
+    Right csInsns -> map (liftX86 modes) csInsns
 
 -- Takes the processor mode, writable address ranges, and executable code. Validates
 -- memory accesses and returns a simplified Stmt in the IR that is semantically

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -19,16 +19,16 @@ updateDefinedRegisters regs (Comment _ _) = regs
 updateDefinedRegisters regs (SetReg _ reg expr) =
   let removeAccessedReg rs e = case e of
         GetReg r -> removeRegister rs r
-        Load a b -> foldl removeAccessedReg rs (flatten b)
+        Load a b -> foldl removeAccessedReg rs (flattenExpr b)
         _ -> rs
-  in foldl removeAccessedReg (addRegister regs reg) (flatten expr)
+  in foldl removeAccessedReg (addRegister regs reg) (flattenExpr expr)
 
 updateDefinedRegisters regs (Store _ _ expr) =
   let removeAccessedReg rs e = case e of
         GetReg r -> removeRegister rs r
-        Load a b -> foldl removeAccessedReg rs (flatten b)
+        Load a b -> foldl removeAccessedReg rs (flattenExpr b)
         _ -> rs
-  in foldl removeAccessedReg regs (flatten expr)
+  in foldl removeAccessedReg regs (flattenExpr expr)
 
 updateDefinedRegisters regs (Compound _ stmts) =
   foldl updateDefinedRegisters regs stmts
@@ -91,17 +91,17 @@ updateDefinedAddresses addrs (SetReg (id, valAbs) _ _) =
   let removeAccessedAddr as e = case e of
         Load a b -> do
           rmed <- removeExpr as b
-          foldM removeAccessedAddr rmed (flatten b)
+          foldM removeAccessedAddr rmed (flattenExpr b)
         _ -> return as
-  in foldM removeAccessedAddr addrs (flatten valAbs)
+  in foldM removeAccessedAddr addrs (flattenExpr valAbs)
 
 updateDefinedAddresses addrs (Store (id, destAbs, valAbs) _ _) =
   let removeAccessedAddr as e = case e of
         Load a b -> do
           rmed <- removeExpr as b
-          foldM removeAccessedAddr as (flatten b)
+          foldM removeAccessedAddr as (flattenExpr b)
         _ -> return as
-  in foldM removeAccessedAddr (destAbs:addrs) (flatten valAbs)
+  in foldM removeAccessedAddr (destAbs:addrs) (flattenExpr valAbs)
 
 updateDefinedAddresses addrs (Compound _ stmts) =
   foldM updateDefinedAddresses addrs stmts

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -151,13 +151,16 @@ insertRefs :: MonadIO m => SymExecutionContext -> AbsStmt -> m (SymExecutionCont
 
 insertRefs cin (SetReg (id, absVal) bs a) = do
   relVal <- simplifyExpr <$> substituteRel cin a
-  return (cin { relativeRegisterFile = setRegisterValue (relativeRegisterFile cin) bs (toStaticExpr relVal id) },
+  return (cin { absoluteRegisterFile = setRegisterValue (absoluteRegisterFile cin) bs absVal,
+            relativeRegisterFile = setRegisterValue (relativeRegisterFile cin) bs (toStaticExpr relVal id) },
         SetReg (id, absVal) bs relVal)
 
 insertRefs cin (Store (id, pdestAbs, absVal) pdestRel pvalRel) = do
   pvalRel <- simplifyExpr <$> substituteRel cin pvalRel
+  absoluteMemoryV <- updateMemory (absoluteMemory cin) (pdestAbs, absVal)
   relativeMemoryV <- updateMemory (relativeMemory cin) (pdestAbs, toStaticExpr pvalRel id)
-  return (cin { relativeMemory = relativeMemoryV }, Store (id, pdestAbs, absVal) pdestRel pvalRel)
+  return (cin { absoluteMemory = absoluteMemoryV, relativeMemory = relativeMemoryV },
+        Store (id, pdestAbs, absVal) pdestRel pvalRel)
 
 insertRefs cin (Comment id str) = return (cin, Comment id str)
 

--- a/src/Phasses.hs
+++ b/src/Phasses.hs
@@ -189,7 +189,7 @@ lookupRange :: MonadIO m => [(Expr, Expr)] -> Expr -> Int -> m (Maybe (Expr, Exp
 lookupRange [] _ _ = return Nothing
 
 lookupRange ((rangeStart, rangeEnd):rst) exprStart sz = do
-  let exprEnd = BvaddExpr exprStart (BvExpr (toBv (div sz byte_size_bit) (getExprSize exprStart)))
+  let exprEnd = BvaddExpr exprStart (BvExpr (toBv (div sz byteSizeBit) (getExprSize exprStart)))
   -- The subtractions in the following inequalities are necessary because we are doing
   -- modular arithmetic.
   result <- proveRelation (BvandExpr

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -94,12 +94,12 @@ lookupExpr ((a, b) : e) addr = do
 getMemoryValue :: MonadIO m => [(Expr, Expr)] -> Expr -> Expr -> m Expr
 
 getMemoryValue mem a defaultExpr =
-  let byteCount = div (getExprSize defaultExpr) byte_size_bit
+  let byteCount = div (getExprSize defaultExpr) byteSizeBit
       setByte expr offset = do
         let currentAddress = BvaddExpr a (BvExpr $ toBv offset (getExprSize a))
         contents <- lookupExpr mem currentAddress
         return $ case contents of
-          Just x -> ReplaceExpr (offset*byte_size_bit) expr x
+          Just x -> ReplaceExpr (offset*byteSizeBit) expr x
           -- If nothing was found in memory, then the default byte will remain
           Nothing -> expr
   in foldM setByte defaultExpr [0..byteCount-1]
@@ -145,10 +145,10 @@ assignExpr ((c, d) : e) (a, b) = do
 updateMemory :: MonadIO m => [(Expr, Expr)] -> (Expr, Expr) -> m [(Expr, Expr)]
 
 updateMemory memory (address, value) =
-  let bc = div (getExprSize value) byte_size_bit
+  let bc = div (getExprSize value) byteSizeBit
       updateByte mem x =
         assignExpr mem (BvaddExpr address (BvExpr $ toBv x (getExprSize address)),
-          simplifyExpr $ ExtractExpr (x*byte_size_bit) ((x+1)*byte_size_bit) value)
+          simplifyExpr $ ExtractExpr (x*byteSizeBit) ((x+1)*byteSizeBit) value)
   in foldM updateByte memory [0..bc-1]
 
 -- Represents the state of a processor: register file contents, data memory contents, and

--- a/src/SymbolicEval.hs
+++ b/src/SymbolicEval.hs
@@ -183,7 +183,7 @@ symExecContext modes = SymExecutionContext {
 
 simplifyExprAux :: Expr -> Expr
 
-simplifyExprAux (BvmulExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvmul abv bbv)
+simplifyExprAux (BvmulExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (abv * bbv)
 
 simplifyExprAux (BvudivExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvudiv abv bbv)
 
@@ -197,15 +197,15 @@ simplifyExprAux (BvorExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvor abv bbv)
 
 simplifyExprAux (BvnotExpr (BvExpr abv)) = BvExpr (bvnot abv)
 
-simplifyExprAux (EqualExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (if bvequal abv bbv then toBv 1 1 else toBv 0 1)
+simplifyExprAux (EqualExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (if abv == bbv then toBv 1 1 else toBv 0 1)
 
-simplifyExprAux (BvaddExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvadd abv bbv)
+simplifyExprAux (BvaddExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (abv + bbv)
 
-simplifyExprAux (BvaddExpr a (BvExpr b)) | bvequal b (bvzero $ bvlength b) = a
+simplifyExprAux (BvaddExpr a (BvExpr b)) | b == (bvzero $ bvlength b) = a
 
-simplifyExprAux (BvaddExpr (BvExpr b) a) | bvequal b (bvzero $ bvlength b) = a
+simplifyExprAux (BvaddExpr (BvExpr b) a) | b == (bvzero $ bvlength b) = a
 
-simplifyExprAux (BvsubExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvsub abv bbv)
+simplifyExprAux (BvsubExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (abv - bbv)
 
 simplifyExprAux (BvlshrExpr (BvExpr abv) (BvExpr bbv)) = BvExpr (bvlshr abv bbv)
 
@@ -233,7 +233,7 @@ simplifyExprAux (ZxExpr a (BvExpr bbv)) = BvExpr (zx a bbv)
 
 simplifyExprAux (ZxExpr a e) | a == getExprSize e = e
 
-simplifyExprAux (IteExpr (BvExpr a) b c) = if bvequal a (bvzero $ bvlength a) then c else b
+simplifyExprAux (IteExpr (BvExpr a) b c) = if a == (bvzero $ bvlength a) then c else b
 -- The entire expression is being replaced
 simplifyExprAux (ReplaceExpr l a b) | getExprSize a == getExprSize b = b
 -- Join together two adjacent replacements

--- a/src/X86Sem.hs
+++ b/src/X86Sem.hs
@@ -27,9 +27,9 @@ x86operands inst =
 
 -- Makes an expression representing the address of the next instruction
 
-next_instr_ptr :: [CsMode] -> CsInsn -> Expr
+nextInstrPtr :: [CsMode] -> CsInsn -> Expr
 
-next_instr_ptr modes insn = BvExpr (toBv (insnAddr + insnLen) archBitSize)
+nextInstrPtr modes insn = BvExpr (toBv (insnAddr + insnLen) archBitSize)
   where insnAddr = fromIntegral (address insn)
         insnLen = fromIntegral (length (bytes insn))
         archBitSize = fromIntegral (getArchBitSize modes)
@@ -38,7 +38,7 @@ next_instr_ptr modes insn = BvExpr (toBv (insnAddr + insnLen) archBitSize)
 
 incInsnPtr :: [CsMode] -> CsInsn -> IdStmt
 
-incInsnPtr modes insn = SetReg undefined (getInsnPtr modes) (next_instr_ptr modes insn)
+incInsnPtr modes insn = SetReg undefined (getInsnPtr modes) (nextInstrPtr modes insn)
 
 -- Gets an expression for the given operand. Processor mode may be needed for computing
 -- effective addresses.
@@ -46,7 +46,7 @@ incInsnPtr modes insn = SetReg undefined (getInsnPtr modes) (next_instr_ptr mode
 getOperandAst :: [CsMode] -> CsX86Op -> Expr
 
 getOperandAst modes op =
-  let opBitSize = fromIntegral (size op) * byte_size_bit
+  let opBitSize = fromIntegral (size op) * byteSizeBit
   in case value op of
     (Imm value) -> BvExpr (toBv value opBitSize)
     (Reg reg) -> GetReg (fromX86Reg reg)
@@ -63,125 +63,125 @@ getZxRegister modes reg = ZxExpr (getArchBitSize modes) (GetReg reg)
 getLeaAst :: [CsMode] -> X86OpMemStruct -> Expr
 
 getLeaAst modes mem =
-  (BvaddExpr node_disp (BvaddExpr node_base node_index)) where
-    arch_bit_size = getArchBitSize modes
-    node_base = case base mem of
-      X86RegInvalid -> BvExpr (toBv 0 arch_bit_size)
+  (BvaddExpr nodeDisp (BvaddExpr nodeBase nodeIndex)) where
+    archBitSize = getArchBitSize modes
+    nodeBase = case base mem of
+      X86RegInvalid -> BvExpr (toBv 0 archBitSize)
       reg -> getZxRegister modes (fromX86Reg reg)
-    node_index = case index mem of
-      X86RegInvalid -> BvExpr (toBv 0 arch_bit_size)
-      reg -> BvmulExpr (getZxRegister modes (fromX86Reg reg)) (BvExpr (toBv (scale mem) arch_bit_size))
-    node_disp = BvExpr (toBv (disp' mem) arch_bit_size)
+    nodeIndex = case index mem of
+      X86RegInvalid -> BvExpr (toBv 0 archBitSize)
+      reg -> BvmulExpr (getZxRegister modes (fromX86Reg reg)) (BvExpr (toBv (scale mem) archBitSize))
+    nodeDisp = BvExpr (toBv (disp' mem) archBitSize)
 
 -- Make operation to store the given expression in the given operand
 
 storeStmt :: [CsMode] -> CsX86Op -> Expr -> IdStmt
 
-storeStmt modes operand store_what =
+storeStmt modes operand storeWhat =
   case (value operand) of
-    (Reg reg) -> SetReg undefined (fromX86Reg reg) store_what
-    (Mem mem) -> Store undefined (getLeaAst modes mem) store_what
+    (Reg reg) -> SetReg undefined (fromX86Reg reg) storeWhat
+    (Mem mem) -> Store undefined (getLeaAst modes mem) storeWhat
     _ -> Comment undefined ("Target of store operation is neither a register nor a memory operand.")
 
 -- Make operation to set the zero flag to the value that it would have after some operation
 
-zf_s :: Expr -> CsX86Op -> IdStmt
+zfSem :: Expr -> CsX86Op -> IdStmt
 
-zf_s parent dst =
-  let bv_size = (fromIntegral $ size dst) * 8 in
+zfSem parent dst =
+  let bvSize = (fromIntegral $ size dst) * 8 in
     SetReg undefined (fromX86Flag X86FlagZf) (IteExpr
-      (EqualExpr (ExtractExpr 0 bv_size parent) (BvExpr (toBv 0 bv_size)))
+      (EqualExpr (ExtractExpr 0 bvSize parent) (BvExpr (toBv 0 bvSize)))
       (BvExpr (toBv 1 1))
       (BvExpr (toBv 0 1)))
 
 -- Make operation to set the overflow flag to the value that it would have after an add operation
 
-of_add_s :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
+ofAddSem :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
 
-of_add_s parent dst op1ast op2ast =
-  let bv_size = (fromIntegral $ size dst) * 8 in
-    SetReg undefined (fromX86Flag X86FlagOf) (ExtractExpr (bv_size - 1) bv_size
+ofAddSem parent dst op1ast op2ast =
+  let bvSize = (fromIntegral $ size dst) * 8 in
+    SetReg undefined (fromX86Flag X86FlagOf) (ExtractExpr (bvSize - 1) bvSize
       (BvandExpr
         (BvxorExpr op1ast (BvnotExpr op2ast))
-        (BvxorExpr op1ast (ExtractExpr 0 bv_size parent))))
+        (BvxorExpr op1ast (ExtractExpr 0 bvSize parent))))
 
 -- Make operation to set the carry flag to the value that it would have after an add operation
 
-cf_add_s :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
+cfAddSem :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
 
-cf_add_s parent dst op1ast op2ast =
-  let bv_size = (fromIntegral $ size dst) * 8 in
-    SetReg undefined (fromX86Flag X86FlagCf) (ExtractExpr (bv_size - 1) bv_size
+cfAddSem parent dst op1ast op2ast =
+  let bvSize = (fromIntegral $ size dst) * 8 in
+    SetReg undefined (fromX86Flag X86FlagCf) (ExtractExpr (bvSize - 1) bvSize
       (BvxorExpr (BvandExpr op1ast op2ast)
         (BvandExpr (BvxorExpr
             (BvxorExpr op1ast op2ast)
-            (ExtractExpr 0 bv_size parent))
+            (ExtractExpr 0 bvSize parent))
           (BvxorExpr op1ast op2ast))))
 
 -- Make operation to set the adjust flag to the value that it would have after some operation
 
-af_s :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
+afSem :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
 
-af_s parent dst op1ast op2ast =
-  let bv_size = (fromIntegral $ size dst) * 8 in
+afSem parent dst op1ast op2ast =
+  let bvSize = (fromIntegral $ size dst) * 8 in
     SetReg undefined (fromX86Flag X86FlagAf) (IteExpr
       (EqualExpr
-        (BvExpr (toBv 0x10 bv_size))
+        (BvExpr (toBv 0x10 bvSize))
         (BvandExpr
-          (BvExpr (toBv 0x10 bv_size))
+          (BvExpr (toBv 0x10 bvSize))
           (BvxorExpr
-            (ExtractExpr 0 bv_size parent)
+            (ExtractExpr 0 bvSize parent)
             (BvxorExpr op1ast op2ast))))
       (BvExpr (toBv 1 1))
       (BvExpr (toBv 0 1)))
 
 -- Make operation to set the parity flag to the value that it would have after some operation
 
-pf_s :: Expr -> CsX86Op -> IdStmt
+pfSem :: Expr -> CsX86Op -> IdStmt
 
-pf_s parent dst =
+pfSem parent dst =
   let loop counter =
-        (if counter == byte_size_bit
+        (if counter == byteSizeBit
           then BvExpr (toBv 1 1)
           else (BvxorExpr
             (loop (counter + 1))
             (ExtractExpr 0 1
               (BvlshrExpr
-                (ExtractExpr 0 byte_size_bit parent)
-                (BvExpr (toBv counter byte_size_bit)))))) in
+                (ExtractExpr 0 byteSizeBit parent)
+                (BvExpr (toBv counter byteSizeBit)))))) in
     SetReg undefined (fromX86Flag X86FlagPf) (loop 0)
 
 -- Make operation to set the sign flag to the value that it would have after some operation
 
-sf_s :: Expr -> CsX86Op -> IdStmt
+sfSem :: Expr -> CsX86Op -> IdStmt
 
-sf_s parent dst =
-  let bv_size = (fromIntegral $ size dst) * 8 in
-    SetReg undefined (fromX86Flag X86FlagSf) (ExtractExpr (bv_size - 1) bv_size parent)
+sfSem parent dst =
+  let bvSize = (fromIntegral $ size dst) * 8 in
+    SetReg undefined (fromX86Flag X86FlagSf) (ExtractExpr (bvSize - 1) bvSize parent)
 
 -- Make operation to set the carry flag to the value that it would have after an sub operation
 
-cf_sub_s :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
+cfSubSem :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
 
-cf_sub_s parent dst op1ast op2ast =
-  let bv_size = (fromIntegral $ size dst) * 8 in
-    SetReg undefined (fromX86Flag X86FlagCf) (ExtractExpr (bv_size - 1) bv_size
+cfSubSem parent dst op1ast op2ast =
+  let bvSize = (fromIntegral $ size dst) * 8 in
+    SetReg undefined (fromX86Flag X86FlagCf) (ExtractExpr (bvSize - 1) bvSize
       (BvxorExpr
-        (BvxorExpr op1ast (BvxorExpr op2ast (ExtractExpr 0 bv_size parent)))
+        (BvxorExpr op1ast (BvxorExpr op2ast (ExtractExpr 0 bvSize parent)))
         (BvandExpr
-          (BvxorExpr op1ast (ExtractExpr 0 bv_size parent))
+          (BvxorExpr op1ast (ExtractExpr 0 bvSize parent))
           (BvxorExpr op1ast op2ast))))
 
 -- Make operation to set the overflow flag to the value that it would have after an sub operation
 
-of_sub_s :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
+ofSubSem :: Expr -> CsX86Op -> Expr -> Expr -> IdStmt
 
-of_sub_s parent dst op1ast op2ast =
-  let bv_size = (fromIntegral $ size dst) * 8 in
-    SetReg undefined (fromX86Flag X86FlagOf) (ExtractExpr (bv_size - 1) bv_size
+ofSubSem parent dst op1ast op2ast =
+  let bvSize = (fromIntegral $ size dst) * 8 in
+    SetReg undefined (fromX86Flag X86FlagOf) (ExtractExpr (bvSize - 1) bvSize
       (BvandExpr
         (BvxorExpr op1ast op2ast)
-        (BvxorExpr op1ast (ExtractExpr 0 bv_size parent))))
+        (BvxorExpr op1ast (ExtractExpr 0 bvSize parent))))
 
 getInsnId :: CsInsn -> X86Insn
 
@@ -203,132 +203,132 @@ liftX86 :: [CsMode] -> CsInsn -> IdStmt
 
 liftX86 modes inst | getInsnId inst == X86InsAdd =
   let (dst : src : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst
-      src_ast = getOperandAst modes src
-      add_node = (BvaddExpr dst_ast src_ast)
+      dstAst = getOperandAst modes dst
+      srcAst = getOperandAst modes src
+      addNode = (BvaddExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      storeStmt modes dst add_node,
-      af_s add_node dst dst_ast src_ast,
-      pf_s add_node dst,
-      sf_s add_node dst,
-      zf_s add_node dst,
-      cf_add_s add_node dst dst_ast src_ast,
-      of_add_s add_node dst dst_ast src_ast]
+      storeStmt modes dst addNode,
+      afSem addNode dst dstAst srcAst,
+      pfSem addNode dst,
+      sfSem addNode dst,
+      zfSem addNode dst,
+      cfAddSem addNode dst dstAst srcAst,
+      ofAddSem addNode dst dstAst srcAst]
 
 -- INC instruction
 
 liftX86 modes inst | getInsnId inst == X86InsInc =
   let (dst : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst
-      src_ast = BvExpr (toBv 1 (fromIntegral (size dst * byte_size_bit)))
-      add_node = (BvaddExpr dst_ast src_ast)
+      dstAst = getOperandAst modes dst
+      srcAst = BvExpr (toBv 1 (fromIntegral (size dst * byteSizeBit)))
+      addNode = (BvaddExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      storeStmt modes dst add_node,
-      af_s add_node dst dst_ast src_ast,
-      pf_s add_node dst,
-      sf_s add_node dst,
-      zf_s add_node dst,
-      of_add_s add_node dst dst_ast src_ast]
+      storeStmt modes dst addNode,
+      afSem addNode dst dstAst srcAst,
+      pfSem addNode dst,
+      sfSem addNode dst,
+      zfSem addNode dst,
+      ofAddSem addNode dst dstAst srcAst]
 
 -- SUB instruction
 
 liftX86 modes inst | getInsnId inst == X86InsSub =
   let (dst : src : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst
-      src_ast = getOperandAst modes src
-      sub_node = (BvsubExpr dst_ast src_ast)
+      dstAst = getOperandAst modes dst
+      srcAst = getOperandAst modes src
+      subNode = (BvsubExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      storeStmt modes dst sub_node,
-      af_s sub_node dst dst_ast src_ast,
-      pf_s sub_node dst,
-      sf_s sub_node dst,
-      zf_s sub_node dst,
-      cf_sub_s sub_node dst dst_ast src_ast,
-      of_sub_s sub_node dst dst_ast src_ast]
+      storeStmt modes dst subNode,
+      afSem subNode dst dstAst srcAst,
+      pfSem subNode dst,
+      sfSem subNode dst,
+      zfSem subNode dst,
+      cfSubSem subNode dst dstAst srcAst,
+      ofSubSem subNode dst dstAst srcAst]
 
 -- CMP instruction
 
 liftX86 modes inst | getInsnId inst == X86InsCmp =
   let (dst : src : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst
-      src_ast = SxExpr (fromIntegral (size dst) * byte_size_bit) (getOperandAst modes src)
-      cmp_node = BvsubExpr dst_ast src_ast
+      dstAst = getOperandAst modes dst
+      srcAst = SxExpr (fromIntegral (size dst) * byteSizeBit) (getOperandAst modes src)
+      cmpNode = BvsubExpr dstAst srcAst
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      af_s cmp_node dst dst_ast src_ast,
-      pf_s cmp_node dst,
-      sf_s cmp_node dst,
-      zf_s cmp_node dst,
-      cf_sub_s cmp_node dst dst_ast src_ast,
-      of_sub_s cmp_node dst dst_ast src_ast]
+      afSem cmpNode dst dstAst srcAst,
+      pfSem cmpNode dst,
+      sfSem cmpNode dst,
+      zfSem cmpNode dst,
+      cfSubSem cmpNode dst dstAst srcAst,
+      ofSubSem cmpNode dst dstAst srcAst]
 
 -- XOR instruction
 
 liftX86 modes inst | getInsnId inst == X86InsXor =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      src_ast = getOperandAst modes src_op
-      xor_node = (BvxorExpr dst_ast src_ast)
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      srcAst = getOperandAst modes srcOp
+      xorNode = (BvxorExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      storeStmt modes dst_op xor_node,
+      storeStmt modes dstOp xorNode,
       SetReg undefined (fromX86Flag X86FlagAf) (UndefinedExpr 1),
-      pf_s xor_node dst_op,
-      sf_s xor_node dst_op,
-      zf_s xor_node dst_op,
+      pfSem xorNode dstOp,
+      sfSem xorNode dstOp,
+      zfSem xorNode dstOp,
       SetReg undefined (fromX86Flag X86FlagCf) (BvExpr (toBv 0 1)),
       SetReg undefined (fromX86Flag X86FlagOf) (BvExpr (toBv 0 1))]
 
 -- AND instruction
 
 liftX86 modes inst | getInsnId inst == X86InsAnd =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      src_ast = getOperandAst modes src_op
-      and_node = (BvandExpr dst_ast src_ast)
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      srcAst = getOperandAst modes srcOp
+      andNode = (BvandExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      storeStmt modes dst_op and_node,
+      storeStmt modes dstOp andNode,
       SetReg undefined (fromX86Flag X86FlagAf) (UndefinedExpr 1),
-      pf_s and_node dst_op,
-      sf_s and_node dst_op,
-      zf_s and_node dst_op,
+      pfSem andNode dstOp,
+      sfSem andNode dstOp,
+      zfSem andNode dstOp,
       SetReg undefined (fromX86Flag X86FlagCf) (BvExpr (toBv 0 1)),
       SetReg undefined (fromX86Flag X86FlagOf) (BvExpr (toBv 0 1))]
 
 -- TEST instruction
 
 liftX86 modes inst | getInsnId inst == X86InsTest =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      src_ast = getOperandAst modes src_op
-      test_node = (BvandExpr dst_ast src_ast)
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      srcAst = getOperandAst modes srcOp
+      testNode = (BvandExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
       SetReg undefined (fromX86Flag X86FlagAf) (UndefinedExpr 1),
-      pf_s test_node dst_op,
-      sf_s test_node dst_op,
-      zf_s test_node dst_op,
+      pfSem testNode dstOp,
+      sfSem testNode dstOp,
+      zfSem testNode dstOp,
       SetReg undefined (fromX86Flag X86FlagCf) (BvExpr (toBv 0 1)),
       SetReg undefined (fromX86Flag X86FlagOf) (BvExpr (toBv 0 1))]
 
 -- OR instruction
 
 liftX86 modes inst | getInsnId inst == X86InsOr =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      src_ast = getOperandAst modes src_op
-      and_node = (BvorExpr dst_ast src_ast)
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      srcAst = getOperandAst modes srcOp
+      andNode = (BvorExpr dstAst srcAst)
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      storeStmt modes dst_op and_node,
+      storeStmt modes dstOp andNode,
       SetReg undefined (fromX86Flag X86FlagAf) (UndefinedExpr 1),
-      pf_s and_node dst_op,
-      sf_s and_node dst_op,
-      zf_s and_node dst_op,
+      pfSem andNode dstOp,
+      sfSem andNode dstOp,
+      zfSem andNode dstOp,
       SetReg undefined (fromX86Flag X86FlagCf) (BvExpr (toBv 0 1)),
       SetReg undefined (fromX86Flag X86FlagOf) (BvExpr (toBv 0 1))]
 
@@ -337,65 +337,65 @@ liftX86 modes inst | getInsnId inst == X86InsOr =
 liftX86 modes inst | getInsnId inst == X86InsPush =
   let (src : _) = x86operands inst
       sp = getStackReg modes
-      arch_byte_size = getArchByteSize modes
+      archByteSize = getArchByteSize modes
       -- If it's an immediate source, the memory access is always based on the arch size
-      op_size = case (value src) of
-        (Imm _) -> arch_byte_size
+      opSize = case (value src) of
+        (Imm _) -> archByteSize
         _ -> fromIntegral $ size src
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      SetReg undefined sp (BvsubExpr (GetReg sp) (BvExpr (toBv op_size (arch_byte_size * byte_size_bit)))),
-      Store undefined (GetReg sp) (ZxExpr (op_size * byte_size_bit) (getOperandAst modes src))]
+      SetReg undefined sp (BvsubExpr (GetReg sp) (BvExpr (toBv opSize (archByteSize * byteSizeBit)))),
+      Store undefined (GetReg sp) (ZxExpr (opSize * byteSizeBit) (getOperandAst modes src))]
 
 -- POP instruction
 
 liftX86 modes inst | getInsnId inst == X86InsPop =
   let (dst : _) = x86operands inst
       sp = getStackReg modes
-      arch_bit_size = getArchBitSize modes
-      op_size = fromIntegral $ size dst
+      archBitSize = getArchBitSize modes
+      opSize = fromIntegral $ size dst
       -- Is the ESP register is used as a base register for addressing a destination operand in memory?
-      sp_base = case (value dst) of
-        (Mem mem_struct) -> isSubregisterOf (fromX86Reg (base mem_struct)) sp
+      spBase = case (value dst) of
+        (Mem memStruct) -> isSubregisterOf (fromX86Reg (base memStruct)) sp
         _ -> False
       -- Is the destination register is SP?
-      sp_reg = case (value dst) of
+      spReg = case (value dst) of
         (Reg reg) -> isSubregisterOf (fromX86Reg reg) sp
         _ -> False
       -- An expression of the amount the stack pointer will be increased by
-      delta_val = BvExpr (toBv op_size arch_bit_size)
+      deltaVal = BvExpr (toBv opSize archBitSize)
   in Compound (fromIntegral (address inst))
       ([incInsnPtr modes inst]
-      ++ (includeIf sp_base [SetReg undefined sp (BvaddExpr (GetReg sp) delta_val)])
+      ++ (includeIf spBase [SetReg undefined sp (BvaddExpr (GetReg sp) deltaVal)])
       ++ [storeStmt modes dst
-          (Load (op_size * byte_size_bit)
-            (if sp_base then (BvsubExpr (GetReg sp) delta_val) else (GetReg sp)))]
-      ++ (includeIf (not (sp_base || sp_reg)) [SetReg undefined sp (BvaddExpr (GetReg sp) delta_val)]))
+          (Load (opSize * byteSizeBit)
+            (if spBase then (BvsubExpr (GetReg sp) deltaVal) else (GetReg sp)))]
+      ++ (includeIf (not (spBase || spReg)) [SetReg undefined sp (BvaddExpr (GetReg sp) deltaVal)]))
 
 -- MOV instruction
 
 liftX86 modes inst | getInsnId inst == X86InsMov =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      src_ast = getOperandAst modes src_op
-      dst_size_bit = (fromIntegral $ size dst_op) * byte_size_bit
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      srcAst = getOperandAst modes srcOp
+      dstSizeBit = (fromIntegral $ size dstOp) * byteSizeBit
       -- Segment registers are defined as 32 or 64 bit vectors in order to
       -- avoid having to simulate the GDT. This definition allows users to
       -- directly define their segments offset.
-      node = (case (value dst_op) of
-        (Reg reg) | isSegmentReg reg -> ExtractExpr 0 word_size_bit tmp_node
-        _ -> tmp_node)
-        where tmp_node = case (value src_op) of
-                (Reg reg) | isSegmentReg reg -> ExtractExpr 0 dst_size_bit src_ast
-                _ -> src_ast
-      undef = case (value src_op) of
+      node = (case (value dstOp) of
+        (Reg reg) | isSegmentReg reg -> ExtractExpr 0 wordSizeBit tmpNode
+        _ -> tmpNode)
+        where tmpNode = case (value srcOp) of
+                (Reg reg) | isSegmentReg reg -> ExtractExpr 0 dstSizeBit srcAst
+                _ -> srcAst
+      undef = case (value srcOp) of
         (Reg reg) | isControlReg reg -> True
-        _ -> case (value dst_op) of
+        _ -> case (value dstOp) of
           (Reg reg) | isControlReg reg -> True
           _ -> False
   in Compound (fromIntegral (address inst))
       ([incInsnPtr modes inst,
-      storeStmt modes dst_op node]
+      storeStmt modes dstOp node]
       ++ includeIf undef
           [SetReg undefined (fromX86Flag X86FlagAf) (UndefinedExpr 1),
           SetReg undefined (fromX86Flag X86FlagPf) (UndefinedExpr 1),
@@ -407,96 +407,96 @@ liftX86 modes inst | getInsnId inst == X86InsMov =
 -- MOVZX instruction
 
 liftX86 modes inst | getInsnId inst == X86InsMovzx =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      src_ast = getOperandAst modes src_op
-      dst_size_bit = (fromIntegral $ size dst_op) * byte_size_bit
-      zx_node = ZxExpr dst_size_bit src_ast
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      srcAst = getOperandAst modes srcOp
+      dstSizeBit = (fromIntegral $ size dstOp) * byteSizeBit
+      zxNode = ZxExpr dstSizeBit srcAst
   in Compound (fromIntegral (address inst))
       [incInsnPtr modes inst,
-      storeStmt modes dst_op zx_node]
+      storeStmt modes dstOp zxNode]
 
 -- JMP instruction
 
 liftX86 modes inst | getInsnId inst == X86InsJmp =
-  let (src_op : _ ) = x86operands inst
-      src_ast = getOperandAst modes src_op
-  in Compound (fromIntegral (address inst)) [SetReg undefined (getInsnPtr modes) src_ast]
+  let (srcOp : _ ) = x86operands inst
+      srcAst = getOperandAst modes srcOp
+  in Compound (fromIntegral (address inst)) [SetReg undefined (getInsnPtr modes) srcAst]
 
 -- JE instruction
 
 liftX86 modes inst | getInsnId inst == X86InsJe =
-  let (src_op : _ ) = x86operands inst
-      src_ast = getOperandAst modes src_op
-      insn_ptr = getInsnPtr modes
+  let (srcOp : _ ) = x86operands inst
+      srcAst = getOperandAst modes srcOp
+      insnPtr = getInsnPtr modes
   in Compound (fromIntegral (address inst))
-      [SetReg undefined insn_ptr
+      [SetReg undefined insnPtr
         (IteExpr (EqualExpr (GetReg (fromX86Flag X86FlagZf)) (BvExpr (toBv 1 1)))
-          src_ast
-          (next_instr_ptr modes inst))]
+          srcAst
+          (nextInstrPtr modes inst))]
 
 -- JNE instruction
 
 liftX86 modes inst | getInsnId inst == X86InsJne =
-  let (src_op : _ ) = x86operands inst
-      src_ast = getOperandAst modes src_op
-      insn_ptr = getInsnPtr modes
+  let (srcOp : _ ) = x86operands inst
+      srcAst = getOperandAst modes srcOp
+      insnPtr = getInsnPtr modes
   in Compound (fromIntegral (address inst))
-      [SetReg undefined insn_ptr
+      [SetReg undefined insnPtr
         (IteExpr (EqualExpr (GetReg (fromX86Flag X86FlagZf)) (BvExpr (toBv 0 1)))
-          src_ast
-          (next_instr_ptr modes inst))]
+          srcAst
+          (nextInstrPtr modes inst))]
 
 -- CALL instruction
 
 liftX86 modes inst | getInsnId inst == X86InsCall =
-  let (src_op : _ ) = x86operands inst
-      src_ast = getOperandAst modes src_op
+  let (srcOp : _ ) = x86operands inst
+      srcAst = getOperandAst modes srcOp
       sp = getStackReg modes
-      arch_byte_size = getArchByteSize modes
-      arch_bit_size = getArchBitSize modes
+      archByteSize = getArchByteSize modes
+      archBitSize = getArchBitSize modes
   in Compound (fromIntegral (address inst))
-      [SetReg undefined sp (BvsubExpr (GetReg sp) (BvExpr (toBv arch_byte_size arch_bit_size))),
-      Store undefined (GetReg sp) (next_instr_ptr modes inst),
-      SetReg undefined (getInsnPtr modes) (ZxExpr arch_bit_size src_ast)]
+      [SetReg undefined sp (BvsubExpr (GetReg sp) (BvExpr (toBv archByteSize archBitSize))),
+      Store undefined (GetReg sp) (nextInstrPtr modes inst),
+      SetReg undefined (getInsnPtr modes) (ZxExpr archBitSize srcAst)]
 
 -- RET instruction
 
 liftX86 modes inst | getInsnId inst == X86InsRet =
   let operands = x86operands inst
       sp = getStackReg modes
-      insn_ptr = getInsnPtr modes
-      arch_byte_size = getArchByteSize modes
+      insnPtr = getInsnPtr modes
+      archByteSize = getArchByteSize modes
   in Compound (fromIntegral (address inst))
-      ([SetReg undefined insn_ptr (GetReg sp),
-      SetReg undefined sp (BvaddExpr (GetReg sp) (BvExpr (toBv arch_byte_size (arch_byte_size * byte_size_bit))))]
+      ([SetReg undefined insnPtr (GetReg sp),
+      SetReg undefined sp (BvaddExpr (GetReg sp) (BvExpr (toBv archByteSize (archByteSize * byteSizeBit))))]
       ++ includeIf (length operands > 0)
-          (let src_ast = getOperandAst modes (head operands)
-          in [SetReg undefined sp (BvaddExpr (GetReg sp) (ZxExpr (arch_byte_size * byte_size_bit) src_ast))]))
+          (let srcAst = getOperandAst modes (head operands)
+          in [SetReg undefined sp (BvaddExpr (GetReg sp) (ZxExpr (archByteSize * byteSizeBit) srcAst))]))
 
 -- LEA instruction
 
 liftX86 modes inst | getInsnId inst == X86InsLea =
-  let (dst_op : src_op : _ ) = x86operands inst
-      dst_ast = getOperandAst modes dst_op
-      dst_size = fromIntegral (size dst_op * byte_size_bit)
-      src_ea_size = getArchBitSize modes
+  let (dstOp : srcOp : _ ) = x86operands inst
+      dstAst = getOperandAst modes dstOp
+      dstSize = fromIntegral (size dstOp * byteSizeBit)
+      srcEaSize = getArchBitSize modes
   in Compound (fromIntegral (address inst)) [
       incInsnPtr modes inst,
-      case value src_op of
+      case value srcOp of
         Imm value ->
           Comment undefined ("Memory operand expected in " ++ show inst ++ ", but immediate value found instead. Ignoring opcode.")
         Reg reg ->
           Comment undefined ("Memory operand expected in " ++ show inst ++ ", but register value found instead. Ignoring opcode.")
         Mem mem ->
-          let src_ea = getLeaAst modes mem
-              src_ea_fitted =
-                if dst_size > src_ea_size then
-                  ZxExpr dst_size src_ea
-                else if dst_size < src_ea_size then
-                  ExtractExpr 0 dst_size src_ea
-                else src_ea
-          in storeStmt modes dst_op src_ea_fitted]
+          let srcEa = getLeaAst modes mem
+              srcEaFitted =
+                if dstSize > srcEaSize then
+                  ZxExpr dstSize srcEa
+                else if dstSize < srcEaSize then
+                  ExtractExpr 0 dstSize srcEa
+                else srcEa
+          in storeStmt modes dstOp srcEaFitted]
 
 -- Otherwise put in a comment to the effect that the instruction is not supported
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,6 +9,9 @@ import Hapstone.Internal.Capstone as Capstone
 import Phasses
 import EvalAst
 import Hapstone.Internal.X86 as X86
+import BitVector
+import Control.Exception
+import Data.Functor
 
 main :: IO ()
 main = defaultMain $
@@ -17,8 +20,37 @@ main = defaultMain $
     , testSym
     , deadSetRegTest0
     , deadSetRegTest1
+    , deadSetRegTest2
+    , deadSetRegTest3
+    , deadStoreTest0
+    , deadStoreTest1
     --, testBlockOne
   ]
+
+-- A Pattern is a predicate that returns True for values matching the Pattern, and False
+-- otherwise. A Pattern is treated as if it returned False in the case that applying it
+-- yields a PatternMatchFail.
+
+type Pattern a = a -> Bool
+
+-- Count the number of items in the given list that match the given pattern
+
+countPattern :: [a] -> Pattern a -> IO Int
+
+countPattern [] _ = return 0
+
+countPattern (x:xs) pat = catch
+  (do
+    a <- evaluate $ pat x
+    b <- countPattern xs pat
+    return ((fromEnum a) + b))
+  (\e -> let _ = (e :: PatternMatchFail) in countPattern xs pat)
+
+-- Count the number of items in the given statement that match the given pattern
+
+countStmtPattern :: Stmt a b c d -> Pattern (Stmt a b c d) -> IO Int
+
+countStmtPattern stmt pat = countPattern (flattenStmt stmt) pat
 
 testLift :: TestTree
 
@@ -29,8 +61,8 @@ testLift =
                  0xB8, 0x02, 0x00, 0x00, 0x00] -- mov eax, 0x2
     l <- decompile modes (allMemory modes) input
     l @?= Compound (-1) [Compound (-1) [Compound 0 [Compound 1 [], Compound 4
-            [SetReg 5 (1472,1504) (BvExpr (10,32)),
-            SetReg 6 (0,32) (BvExpr (2,32))]]]]
+            [SetReg 5 (1472,1504) (BvExpr (Bv(10,32))),
+            SetReg 6 (0,32) (BvExpr (Bv(2,32)))]]]]
 
 testSym :: TestTree
 
@@ -46,8 +78,8 @@ testSym =
     l <- decompile modes (allMemory modes) input
     l @?= Compound (-1) [Compound (-1) [Compound 0 [Compound 1 [],Compound 4 [], Compound 13 [],
             Compound 22 [],Compound 31 [SetReg 33 (0,32) (GetReg (64,96))], Compound 34
-              [SetReg 35 (1472,1504) (BvExpr (19,32)),
-              SetReg 36 (0,32) (BvaddExpr (ReferenceExpr 32 33) (BvExpr (20,32)))]]]]
+              [SetReg 35 (1472,1504) (BvExpr (Bv(19,32))),
+              SetReg 36 (0,32) (BvaddExpr (ReferenceExpr 32 33) (BvExpr (Bv(20,32))))]]]]
 
 -- The approach taken in the following tests is to lift executable code into the IR,
 -- decompile executable code into the IR, numerically execute both IRs with the same
@@ -76,8 +108,62 @@ deadSetRegTest1 =
     let input = [0xB8, 0x0A, 0x00, 0x00, 0x00, -- mov eax, 0xa
                 0xB8, 0x14, 0x00, 0x00, 0x00] -- mov eax, 0x14
     decompiled <- decompile modes (allMemory modes) input
-    let count acc (SetReg _ reg _) | reg == fromX86Reg X86RegEax = acc + 1
-        count acc _ = acc
     -- Ensure that EAX is only set once
-    foldl count (0 :: Int) (flattenStmt decompiled) @?= 1
-    
+    count <- countStmtPattern decompiled (\(SetReg _ reg _) -> reg == fromX86Reg X86RegEax)
+    count @?= 1
+
+deadSetRegTest2 :: TestTree
+
+deadSetRegTest2 =
+  testCase "dead SetReg test 2" $ do
+    let modes = [Capstone.CsMode32]
+    let input = [0xB8, 0x0A, 0x00, 0x00, 0x00, -- mov eax, 0xa
+                0x6A, 0x1E, -- push 0x1e
+                0x8D, 0x40, 0x14] -- lea eax,[eax+0x14]
+    let initState = zeroStackReg $ zeroInsnPtr (numExecContext modes)
+    lifted <- lift modes input
+    decompiled <- decompile modes (allMemory modes) input
+    -- Ensure that both IRs do the same things to the machine
+    fetchExec initState lifted @?= exec initState decompiled
+
+deadSetRegTest3 :: TestTree
+
+deadSetRegTest3 =
+  testCase "dead SetReg test 3" $ do
+    let modes = [Capstone.CsMode32]
+    let input = [0xB8, 0x0A, 0x00, 0x00, 0x00, -- mov eax, 0xa
+                0x6A, 0x1E, -- push 0x1e
+                0x8D, 0x40, 0x14] -- lea eax,[eax+0x14]
+    decompiled <- decompile modes (allMemory modes) input
+    -- Ensure that EAX is only set once
+    count <- countStmtPattern decompiled (\(SetReg _ reg _) -> reg == fromX86Reg X86RegEax)
+    count @?= 1
+
+deadStoreTest0 :: TestTree
+
+deadStoreTest0 =
+  testCase "dead Store test 0" $ do
+    let modes = [Capstone.CsMode32]
+    let input = [0xC7, 0x00, 0x0A, 0x00, 0x00, 0x00, -- mov DWORD PTR [eax], 0xa
+                0x8B, 0x18, -- mov ebx, DWORD PTR [eax]
+                0x83, 0xC3, 0x1E, -- add ebx, 0x1e
+                0x89, 0x18] -- mov DWORD PTR [eax], ebx
+    decompiled <- decompile modes (allMemory modes) input
+    -- Ensure that DWORD PTR [EAX] is only set once
+    count <- countStmtPattern decompiled (\(Store _ (GetReg reg) _) -> reg == fromX86Reg X86RegEax)
+    count @?= 1
+
+deadStoreTest1 :: TestTree
+
+deadStoreTest1 =
+  testCase "dead Store test 0" $ do
+    let modes = [Capstone.CsMode32]
+    let input = [0xC7, 0x00, 0x0A, 0x00, 0x00, 0x00, -- mov DWORD PTR [eax], 0xa
+                0x8B, 0x18, -- mov ebx, DWORD PTR [eax]
+                0x83, 0xC3, 0x1E, -- add ebx, 0x1e
+                0x89, 0x18] -- mov DWORD PTR [eax], ebx
+    decompiled <- decompile modes (allMemory modes) input
+    -- Ensure that 0x28 is stored in DWORD PTR [EAX] is exactly once
+    count <- countStmtPattern decompiled (\(Store _ (GetReg reg) (BvExpr 0x28)) -> reg == fromX86Reg X86RegEax)
+    count @?= 1
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -45,3 +45,11 @@ testSym =
               [SetReg 35 (1472,1504) (BvExpr (19,32)),
               SetReg 36 (0,32) (BvaddExpr (ReferenceExpr 32 33) (BvExpr (20,32)))]]]]
 
+{-deadSetRegTest0 :: TestTree
+
+deadSetRegTest0 =
+  testCase "dead SetReg test 0" $ do
+    let modes = [Capstone.CsMode32]
+    let input = [0xB8, 0x0A, 0x00, 0x00, 0x00, -- mov eax, 0xa
+                0xB8, 0x14, 0x00, 0x00, 0x00 -- mov eax, 0x14-}
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,12 +7,16 @@ import Lifter
 import Ast
 import Hapstone.Internal.Capstone as Capstone
 import Phasses
+import EvalAst
+import Hapstone.Internal.X86 as X86
 
 main :: IO ()
 main = defaultMain $
   testGroup "Lifter" [
       testLift
     , testSym
+    , deadSetRegTest0
+    , deadSetRegTest1
     --, testBlockOne
   ]
 
@@ -45,11 +49,35 @@ testSym =
               [SetReg 35 (1472,1504) (BvExpr (19,32)),
               SetReg 36 (0,32) (BvaddExpr (ReferenceExpr 32 33) (BvExpr (20,32)))]]]]
 
-{-deadSetRegTest0 :: TestTree
+-- The approach taken in the following tests is to lift executable code into the IR,
+-- decompile executable code into the IR, numerically execute both IRs with the same
+-- initial machine state, and assert that the final machine states are equal. Various
+-- properties of the transformed IR (such as the number of Load expressions it contains)
+-- are also checked.
+
+deadSetRegTest0 :: TestTree
 
 deadSetRegTest0 =
   testCase "dead SetReg test 0" $ do
     let modes = [Capstone.CsMode32]
     let input = [0xB8, 0x0A, 0x00, 0x00, 0x00, -- mov eax, 0xa
-                0xB8, 0x14, 0x00, 0x00, 0x00 -- mov eax, 0x14-}
+                0xB8, 0x14, 0x00, 0x00, 0x00] -- mov eax, 0x14
+    let initState = zeroInsnPtr (numExecContext modes)
+    lifted <- lift modes input
+    decompiled <- decompile modes (allMemory modes) input
+    -- Ensure that both IRs do the same things to the machine
+    fetchExec initState lifted @?= exec initState decompiled
 
+deadSetRegTest1 :: TestTree
+
+deadSetRegTest1 =
+  testCase "dead SetReg test 1" $ do
+    let modes = [Capstone.CsMode32]
+    let input = [0xB8, 0x0A, 0x00, 0x00, 0x00, -- mov eax, 0xa
+                0xB8, 0x14, 0x00, 0x00, 0x00] -- mov eax, 0x14
+    decompiled <- decompile modes (allMemory modes) input
+    let count acc (SetReg _ reg _) | reg == fromX86Reg X86RegEax = acc + 1
+        count acc _ = acc
+    -- Ensure that EAX is only set once
+    foldl count (0 :: Int) (flattenStmt decompiled) @?= 1
+    


### PR DESCRIPTION
Corrected the semantics for an unsupported instruction. numExecContext no longer modifies the instruction pointer - a separate function now does that.

Starting to write tests. Algebraic tests assert properties of the IR when viewed as an abstract syntax tree. Numerical tests assert properties of the output the IR produces when given concrete inputs.